### PR TITLE
fix: use the getStringProperty method of the DataAddress

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -46,9 +46,9 @@ maven/mavencentral/io.netty/netty-resolver/4.1.94.Final, Apache-2.0 AND BSD-3-Cl
 maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.94.Final, Apache-2.0, approved, #6366
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.28.0, Apache-2.0, approved, #9662
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.28.0, Apache-2.0, approved, #9661
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.28.0, Apache-2.0, approved, #9663
+maven/mavencentral/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.29.0, , restricted, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.29.0, , restricted, clearlydefined
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined

--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3BucketProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3BucketProvisionedResource.java
@@ -34,16 +34,16 @@ public class S3BucketProvisionedResource extends ProvisionedDataDestinationResou
     private String role;
 
     public String getRegion() {
-        return getDataAddress().getProperty(REGION);
+        return getDataAddress().getStringProperty(REGION);
     }
 
     public String getBucketName() {
-        return getDataAddress().getProperty(BUCKET_NAME);
+        return getDataAddress().getStringProperty(BUCKET_NAME);
     }
 
     @Override
     public String getResourceName() {
-        return dataAddress.getProperty(BUCKET_NAME);
+        return dataAddress.getStringProperty(BUCKET_NAME);
     }
 
     public String getRole() {

--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGenerator.java
@@ -32,14 +32,14 @@ public class S3ConsumerResourceDefinitionGenerator implements ConsumerResourceDe
 
     @Override
     public ResourceDefinition generate(DataRequest dataRequest, Policy policy) {
-        if (dataRequest.getDataDestination().getProperty(S3BucketSchema.REGION) == null) {
+        if (dataRequest.getDataDestination().getStringProperty(S3BucketSchema.REGION) == null) {
             // FIXME generate region from policy engine
-            return S3BucketResourceDefinition.Builder.newInstance().id(randomUUID().toString()).bucketName(dataRequest.getDataDestination().getProperty(S3BucketSchema.BUCKET_NAME)).regionId(Region.US_EAST_1.id()).build();
+            return S3BucketResourceDefinition.Builder.newInstance().id(randomUUID().toString()).bucketName(dataRequest.getDataDestination().getStringProperty(S3BucketSchema.BUCKET_NAME)).regionId(Region.US_EAST_1.id()).build();
         }
         var destination = dataRequest.getDataDestination();
         var id = randomUUID().toString();
 
-        return S3BucketResourceDefinition.Builder.newInstance().id(id).bucketName(destination.getProperty(S3BucketSchema.BUCKET_NAME)).regionId(destination.getProperty(S3BucketSchema.REGION)).build();
+        return S3BucketResourceDefinition.Builder.newInstance().id(id).bucketName(destination.getStringProperty(S3BucketSchema.BUCKET_NAME)).regionId(destination.getStringProperty(S3BucketSchema.REGION)).build();
     }
 
     @Override

--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusChecker.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusChecker.java
@@ -44,8 +44,8 @@ public class S3StatusChecker implements StatusChecker {
     public boolean isComplete(TransferProcess transferProcess, List<ProvisionedResource> resources) {
         if (resources.isEmpty()) {
             var destination = transferProcess.getDataRequest().getDataDestination();
-            var bucketName = destination.getProperty(S3BucketSchema.BUCKET_NAME);
-            var region = destination.getProperty(S3BucketSchema.REGION);
+            var bucketName = destination.getStringProperty(S3BucketSchema.BUCKET_NAME);
+            var region = destination.getStringProperty(S3BucketSchema.REGION);
             return checkBucket(bucketName, region);
         } else {
             for (var resource : resources) {

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
@@ -85,16 +85,16 @@ public class S3DataSinkFactory implements DataSinkFactory {
         var secret = vault.resolveSecret(destination.getKeyName());
         if (secret != null) {
             var secretToken = typeManager.readValue(secret, AwsTemporarySecretToken.class);
-            client = clientProvider.s3Client(destination.getProperty(REGION), secretToken);
+            client = clientProvider.s3Client(destination.getStringProperty(REGION), secretToken);
         } else if (credentialsValidation.apply(destination).succeeded()) {
-            var secretToken = new AwsSecretToken(destination.getProperty(ACCESS_KEY_ID), destination.getProperty(SECRET_ACCESS_KEY));
-            client = clientProvider.s3Client(destination.getProperty(REGION), secretToken);
+            var secretToken = new AwsSecretToken(destination.getStringProperty(ACCESS_KEY_ID), destination.getStringProperty(SECRET_ACCESS_KEY));
+            client = clientProvider.s3Client(destination.getStringProperty(REGION), secretToken);
         } else {
-            client = clientProvider.s3Client(destination.getProperty(REGION));
+            client = clientProvider.s3Client(destination.getStringProperty(REGION));
         }
 
         return S3DataSink.Builder.newInstance()
-                .bucketName(destination.getProperty(BUCKET_NAME))
+                .bucketName(destination.getStringProperty(BUCKET_NAME))
                 .keyName(destination.getKeyName())
                 .requestId(request.getId())
                 .executorService(executorService)

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -76,16 +76,16 @@ public class S3DataSourceFactory implements DataSourceFactory {
         var secret = vault.resolveSecret(source.getKeyName());
         if (secret != null) {
             var secretToken = typeManager.readValue(secret, AwsSecretToken.class);
-            client = clientProvider.s3Client(source.getProperty(REGION), secretToken);
+            client = clientProvider.s3Client(source.getStringProperty(REGION), secretToken);
         } else if (credentialsValidation.apply(source).succeeded()) {
-            var secretToken = new AwsSecretToken(source.getProperty(ACCESS_KEY_ID), source.getProperty(SECRET_ACCESS_KEY));
-            client = clientProvider.s3Client(source.getProperty(REGION), secretToken);
+            var secretToken = new AwsSecretToken(source.getStringProperty(ACCESS_KEY_ID), source.getStringProperty(SECRET_ACCESS_KEY));
+            client = clientProvider.s3Client(source.getStringProperty(REGION), secretToken);
         } else {
-            client = clientProvider.s3Client(source.getProperty(REGION));
+            client = clientProvider.s3Client(source.getStringProperty(REGION));
         }
 
         return S3DataSource.Builder.newInstance()
-                .bucketName(source.getProperty(BUCKET_NAME))
+                .bucketName(source.getStringProperty(BUCKET_NAME))
                 .keyName(source.getKeyName())
                 .client(client)
                 .build();

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/validation/S3DataAddressCredentialsValidationRule.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/validation/S3DataAddressCredentialsValidationRule.java
@@ -36,6 +36,6 @@ public class S3DataAddressCredentialsValidationRule implements ValidationRule<Da
                 )
         );
 
-        return composite.apply(dataAddress.getProperties());
+        return composite.apply(dataAddress);
     }
 }

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/validation/S3DataAddressValidationRule.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/validation/S3DataAddressValidationRule.java
@@ -36,6 +36,6 @@ public class S3DataAddressValidationRule implements ValidationRule<DataAddress> 
                 )
         );
 
-        return composite.apply(dataAddress.getProperties());
+        return composite.apply(dataAddress);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Fixes compile errors that arose due to the `getProperty` -> `getStringProperty` transition in the `DataAddress` class.

## Why it does that

compile errors

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_
