### PR TITLE
feat: make endpointOverride configurable by DataAddress

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -87,10 +87,17 @@ jobs:
       S3_SECRET_ACCESS_KEY: password
 
     services:
-      minio:
+      minio-source:
         image: bitnami/minio:latest
         ports:
           - 9000:9000
+        env:
+          MINIO_ROOT_USER: root
+          MINIO_ROOT_PASSWORD: password
+      minio-destination:
+        image: bitnami/minio:latest
+        ports:
+          - 9002:9000
         env:
           MINIO_ROOT_USER: root
           MINIO_ROOT_PASSWORD: password

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProvider.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProvider.java
@@ -67,4 +67,6 @@ public interface AwsClientProvider {
      * Releases resources used by the provider.
      */
     void shutdown();
+
+    void configureEndpointOverride(String endpointOverride);
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProvider.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProvider.java
@@ -9,12 +9,12 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *       ZF Friedrichshafen AG - Initial implementation
  *
  */
 
 package org.eclipse.edc.aws.s3;
 
-import org.eclipse.edc.connector.transfer.spi.types.SecretToken;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import software.amazon.awssdk.services.iam.IamAsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -37,16 +37,10 @@ import software.amazon.awssdk.services.sts.StsAsyncClient;
  */
 @ExtensionPoint
 public interface AwsClientProvider {
-
     /**
-     * Returns the client for the specified region with the secret token credentials
+     * Returns the client for the specified s3ClientRequest
      */
-    S3Client s3Client(String region, SecretToken secretToken);
-
-    /**
-     * Returns the s3 client for the specified region
-     */
-    S3Client s3Client(String region);
+    S3Client s3Client(S3ClientRequest s3ClientRequest);
 
     /**
      * Returns the s3 async client for the specified region
@@ -67,6 +61,4 @@ public interface AwsClientProvider {
      * Releases resources used by the provider.
      */
     void shutdown();
-
-    void configureEndpointOverride(String endpointOverride);
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.edc.aws.s3;
 
-import java.net.URISyntaxException;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 
 public class AwsClientProviderConfiguration {

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.aws.s3;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Objects;
 
 public class AwsClientProviderConfiguration {
@@ -28,9 +27,7 @@ public class AwsClientProviderConfiguration {
     private URI endpointOverride;
     private int threadPoolSize = DEFAULT_AWS_ASYNC_CLIENT_THREAD_POOL_SIZE;
 
-    private AwsClientProviderConfiguration() {
-
-    }
+    private AwsClientProviderConfiguration() {}
 
     public AwsCredentialsProvider getCredentialsProvider() {
         return credentialsProvider;
@@ -42,14 +39,6 @@ public class AwsClientProviderConfiguration {
 
     public int getThreadPoolSize() {
         return threadPoolSize;
-    }
-
-    public void setEndpointOverride(String endpointOverride) {
-        try {
-            this.endpointOverride = new URI(endpointOverride);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Cannot set endpointOverride (%s) as URI", endpointOverride));
-        }
     }
 
     public static class Builder {

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderConfiguration.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.aws.s3;
 
+import java.net.URISyntaxException;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.net.URI;
@@ -41,6 +42,14 @@ public class AwsClientProviderConfiguration {
 
     public int getThreadPoolSize() {
         return threadPoolSize;
+    }
+
+    public void setEndpointOverride(String endpointOverride) {
+        try {
+            this.endpointOverride = new URI(endpointOverride);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(String.format("Cannot set endpointOverride (%s) as URI", endpointOverride));
+        }
     }
 
     public static class Builder {

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
@@ -62,7 +62,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
     public S3Client s3Client(String region, SecretToken token) {
         if (token instanceof AwsTemporarySecretToken temporary) {
             var credentials = AwsSessionCredentials.create(temporary.getAccessKeyId(), temporary.getSecretAccessKey(),
-                temporary.getSessionToken());
+                    temporary.getSessionToken());
             return createS3Client(credentials, region);
         }
         if (token instanceof AwsSecretToken secretToken) {
@@ -111,8 +111,8 @@ public class AwsClientProviderImpl implements AwsClientProvider {
     private S3Client createS3Client(AwsCredentials credentials, String region) {
         var credentialsProvider = StaticCredentialsProvider.create(credentials);
         var builder = S3Client.builder()
-            .credentialsProvider(credentialsProvider)
-            .region(Region.of(region));
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -121,8 +121,8 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private S3Client createS3Client(String region) {
         S3ClientBuilder builder = S3Client.builder()
-            .credentialsProvider(credentialsProvider)
-            .region(Region.of(region));
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -131,9 +131,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private S3AsyncClient createS3AsyncClient(String region) {
         var builder = S3AsyncClient.builder()
-            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-            .credentialsProvider(credentialsProvider)
-            .region(Region.of(region));
+                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -142,9 +142,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private StsAsyncClient createStsClient(String region) {
         var builder = StsAsyncClient.builder()
-            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-            .credentialsProvider(credentialsProvider)
-            .region(Region.of(region));
+                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region));
 
         handleEndpointOverride(builder);
 
@@ -153,9 +153,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private IamAsyncClient createIamAsyncClient() {
         var builder = IamAsyncClient.builder()
-            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-            .credentialsProvider(credentialsProvider)
-            .region(Region.AWS_GLOBAL);
+                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+                .credentialsProvider(credentialsProvider)
+                .region(Region.AWS_GLOBAL);
 
         handleEndpointOverride(builder);
 
@@ -166,7 +166,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         var endpointOverride = configuration.getEndpointOverride();
         if (endpointOverride != null) {
             builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
-                .endpointOverride(endpointOverride);
+                    .endpointOverride(endpointOverride);
         }
     }
 

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 import java.util.Map;
@@ -59,17 +60,16 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     @Override
     public S3Client s3Client(String region, SecretToken token) {
-        if (token instanceof AwsTemporarySecretToken) {
-            var temporary = (AwsTemporarySecretToken) token;
-            var credentials = AwsSessionCredentials.create(temporary.getAccessKeyId(), temporary.getSecretAccessKey(), temporary.getSessionToken());
+        if (token instanceof AwsTemporarySecretToken temporary) {
+            var credentials = AwsSessionCredentials.create(temporary.getAccessKeyId(), temporary.getSecretAccessKey(),
+                temporary.getSessionToken());
             return createS3Client(credentials, region);
-        } else if (token instanceof AwsSecretToken) {
-            var secretToken = (AwsSecretToken) token;
+        }
+        if (token instanceof AwsSecretToken secretToken) {
             var credentials = AwsBasicCredentials.create(secretToken.getAccessKeyId(), secretToken.getSecretAccessKey());
             return createS3Client(credentials, region);
-        } else {
-            throw new EdcException(String.format("SecretToken %s is not supported", token.getClass()));
         }
+        throw new EdcException(String.format("SecretToken %s is not supported", token.getClass()));
     }
 
     @Override
@@ -100,11 +100,19 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         stsAsyncClients.values().forEach(SdkAutoCloseable::close);
     }
 
+    @Override
+    public void configureEndpointOverride(String endpointOverride) {
+        if (StringUtils.isBlank(endpointOverride)) {
+            return;
+        }
+        configuration.setEndpointOverride(endpointOverride);
+    }
+
     private S3Client createS3Client(AwsCredentials credentials, String region) {
         var credentialsProvider = StaticCredentialsProvider.create(credentials);
         var builder = S3Client.builder()
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -113,8 +121,8 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private S3Client createS3Client(String region) {
         S3ClientBuilder builder = S3Client.builder()
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -123,9 +131,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private S3AsyncClient createS3AsyncClient(String region) {
         var builder = S3AsyncClient.builder()
-                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(region));
 
         handleBaseEndpointOverride(builder);
 
@@ -134,9 +142,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private StsAsyncClient createStsClient(String region) {
         var builder = StsAsyncClient.builder()
-                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-                .credentialsProvider(credentialsProvider)
-                .region(Region.of(region));
+            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(region));
 
         handleEndpointOverride(builder);
 
@@ -145,9 +153,9 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     private IamAsyncClient createIamAsyncClient() {
         var builder = IamAsyncClient.builder()
-                .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
-                .credentialsProvider(credentialsProvider)
-                .region(Region.AWS_GLOBAL);
+            .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, executor))
+            .credentialsProvider(credentialsProvider)
+            .region(Region.AWS_GLOBAL);
 
         handleEndpointOverride(builder);
 
@@ -158,7 +166,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
         var endpointOverride = configuration.getEndpointOverride();
         if (endpointOverride != null) {
             builder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
-                    .endpointOverride(endpointOverride);
+                .endpointOverride(endpointOverride);
         }
     }
 

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
@@ -20,4 +20,5 @@ public interface S3BucketSchema {
     String BUCKET_NAME = "bucketName";
     String ACCESS_KEY_ID = "accessKeyId";
     String SECRET_ACCESS_KEY = "secretAccessKey";
+    String ENDPOINT_OVERRIDE = "endpointOverride";
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3ClientRequest.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3ClientRequest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3;
+
+import org.eclipse.edc.connector.transfer.spi.types.SecretToken;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class S3ClientRequest {
+
+    private final String region;
+
+    private final String endpointOverride;
+
+    private final SecretToken secretToken;
+
+    private S3ClientRequest(@NotNull String region, String endpointOverride, SecretToken secretToken) {
+        this.region = region;
+        this.endpointOverride = endpointOverride;
+        this.secretToken = secretToken;
+    }
+
+    public static S3ClientRequest from(String region, String endpointOverride) {
+        return new S3ClientRequest(region, endpointOverride, null);
+    }
+
+    public static S3ClientRequest from(String region, String endpointOverride, SecretToken secretToken) {
+        return new S3ClientRequest(region, endpointOverride, secretToken);
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getEndpointOverride() {
+        return endpointOverride;
+    }
+
+    public SecretToken getSecretToken() {
+        return secretToken;
+    }
+
+    @Override
+    public String toString() {
+        return "S3ClientRequest{" +
+            "region='" + region + '\'' +
+            ", endpointOverride='" + endpointOverride + '\'' +
+            ", secretToken=" + secretToken +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        S3ClientRequest that = (S3ClientRequest) o;
+        return Objects.equals(region, that.region) && Objects.equals(endpointOverride, that.endpointOverride) &&
+            Objects.equals(secretToken, that.secretToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(region, endpointOverride, secretToken);
+    }
+}

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3ClientRequest.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3ClientRequest.java
@@ -15,23 +15,8 @@
 package org.eclipse.edc.aws.s3;
 
 import org.eclipse.edc.connector.transfer.spi.types.SecretToken;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-
-public class S3ClientRequest {
-
-    private final String region;
-
-    private final String endpointOverride;
-
-    private final SecretToken secretToken;
-
-    private S3ClientRequest(@NotNull String region, String endpointOverride, SecretToken secretToken) {
-        this.region = region;
-        this.endpointOverride = endpointOverride;
-        this.secretToken = secretToken;
-    }
+public record S3ClientRequest(String region, String endpointOverride, SecretToken secretToken) {
 
     public static S3ClientRequest from(String region, String endpointOverride) {
         return new S3ClientRequest(region, endpointOverride, null);
@@ -41,42 +26,4 @@ public class S3ClientRequest {
         return new S3ClientRequest(region, endpointOverride, secretToken);
     }
 
-    public String getRegion() {
-        return region;
-    }
-
-    public String getEndpointOverride() {
-        return endpointOverride;
-    }
-
-    public SecretToken getSecretToken() {
-        return secretToken;
-    }
-
-    @Override
-    public String toString() {
-        return "S3ClientRequest{" +
-            "region='" + region + '\'' +
-            ", endpointOverride='" + endpointOverride + '\'' +
-            ", secretToken=" + secretToken +
-            '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        S3ClientRequest that = (S3ClientRequest) o;
-        return Objects.equals(region, that.region) && Objects.equals(endpointOverride, that.endpointOverride) &&
-            Objects.equals(secretToken, that.secretToken);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(region, endpointOverride, secretToken);
-    }
 }

--- a/extensions/common/aws/aws-s3-test/README.md
+++ b/extensions/common/aws/aws-s3-test/README.md
@@ -2,15 +2,18 @@
 
 ## Local testing using MinIO
 
-To run AWS integration tests you will need a MinIO instance running:
+To run AWS integration tests you will need a MinIO instances running:
 ```
-docker run -d -p 9000:9000 -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=password bitnami/minio:latest
+ docker run --name miniosource -p 9000:9000 -p 9001:9001 -d -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=password bitnami/minio:latest
+ docker run --name miniodest -p 9002:9000 -p 9003:9001 -d -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=password bitnami/minio:latest
 ```
 
-Then set the two environment variables:
+Then set the two sets of environment variables:
 ```
-S3_ACCESS_KEY_ID=root
-S3_SECRET_ACCESS_KEY=password
+S3_ACCESS_KEY_ID_SOURCE=root
+S3_SECRET_ACCESS_KEY_SOURCE=password
+S3_ACCESS_KEY_ID_DESTINATION=root
+S3_SECRET_ACCESS_KEY_DESTINATION=password
 ```
 
 ## Test using your AWS credential

--- a/extensions/common/aws/aws-s3-test/README.md
+++ b/extensions/common/aws/aws-s3-test/README.md
@@ -8,12 +8,10 @@ To run AWS integration tests you will need a MinIO instances running:
  docker run --name miniodest -p 9002:9000 -p 9003:9001 -d -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=password bitnami/minio:latest
 ```
 
-Then set the two sets of environment variables:
+Then set the two environment variables:
 ```
-S3_ACCESS_KEY_ID_SOURCE=root
-S3_SECRET_ACCESS_KEY_SOURCE=password
-S3_ACCESS_KEY_ID_DESTINATION=root
-S3_SECRET_ACCESS_KEY_DESTINATION=password
+S3_ACCESS_KEY_ID=root
+S3_SECRET_ACCESS_KEY=password
 ```
 
 ## Test using your AWS credential

--- a/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
+++ b/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
@@ -15,45 +15,18 @@
 
 package org.eclipse.edc.aws.s3.testfixtures;
 
-import okhttp3.Request;
-import org.eclipse.edc.aws.s3.AwsClientProvider;
-import org.eclipse.edc.aws.s3.AwsClientProviderConfiguration;
-import org.eclipse.edc.aws.s3.AwsClientProviderImpl;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
-import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
-import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
-import java.net.URI;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
 import static org.eclipse.edc.util.configuration.ConfigurationFunctions.propOrEnv;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class for tests that need an S3 bucket created and deleted on every test run.
@@ -69,196 +42,39 @@ public abstract class AbstractS3Test {
     protected static final String SOURCE_MINIO_ENDPOINT = "http://localhost:9000";
 
     protected static final String DESTINATION_MINIO_ENDPOINT = "http://localhost:9002";
-    protected static final URI SOURCE_S3_ENDPOINT = URI.create(propOrEnv("it.aws.endpoint", SOURCE_MINIO_ENDPOINT));
 
-    protected static final URI DESTINATION_S3_ENDPOINT = URI.create(propOrEnv("it.aws.endpoint", DESTINATION_MINIO_ENDPOINT));
+    protected String bucketName = "test-bucket-" + UUID.randomUUID() + "-" + REGION;
 
-    protected S3AsyncClient s3AsyncSourceClient;
+    protected S3TestClient sourceClient = S3TestClient.create(SOURCE_MINIO_ENDPOINT, REGION);
 
-    protected S3AsyncClient s3AsyncDestinationClient;
-
-    protected final UUID processId = UUID.randomUUID();
-
-    protected String bucketName = createBucketName();
-    private final AwsClientProviderConfiguration sourceConfiguration = AwsClientProviderConfiguration.Builder.newInstance()
-            .credentialsProvider(this::getSourceCredentials)
-            .endpointOverride(SOURCE_S3_ENDPOINT)
-            .build();
-
-    private final AwsClientProviderConfiguration destinationConfiguration = AwsClientProviderConfiguration.Builder.newInstance()
-            .credentialsProvider(this::getDestinationCredentials)
-            .endpointOverride(DESTINATION_S3_ENDPOINT)
-            .build();
-    protected AwsClientProvider sourceClientProvider = new AwsClientProviderImpl(sourceConfiguration);
-
-    protected AwsClientProvider destinationClientProvider = new AwsClientProviderImpl(destinationConfiguration);
+    protected S3TestClient destinationClient = S3TestClient.create(DESTINATION_MINIO_ENDPOINT, REGION);
 
     @BeforeAll
-    static void prepareAll() {
+    void prepareAll() {
         await().atLeast(Duration.ofSeconds(2))
             .atMost(Duration.ofSeconds(15))
             .with()
             .pollInterval(Duration.ofSeconds(2))
             .ignoreException(IOException.class) // thrown by pingMinio
             .ignoreException(ConnectException.class)
-            .until(AbstractS3Test::isBackendAvailable);
+            .until(this::isBackendAvailable);
     }
 
-    private static boolean isBackendAvailable() throws IOException {
-        if (isMinio()) {
-            return isMinioAvailable(SOURCE_S3_ENDPOINT) && isMinioAvailable(DESTINATION_S3_ENDPOINT);
+    private boolean isBackendAvailable() throws IOException {
+        if (sourceClient.isMinio() && destinationClient.isMinio()) {
+            return sourceClient.isAvailable() && destinationClient.isAvailable();
         } else {
             return true;
         }
     }
 
-    private static boolean isMinio() {
-        return SOURCE_MINIO_ENDPOINT.equals(SOURCE_S3_ENDPOINT.toString()) &&
-            DESTINATION_MINIO_ENDPOINT.equals(DESTINATION_S3_ENDPOINT.toString());
-    }
-
-    /**
-     * pings <a href="https://docs.min.io/minio/baremetal/monitoring/healthcheck-probe.html">MinIO's health endpoint</a>
-     *
-     * @return true if HTTP status [200..300[
-     */
-    private static boolean isMinioAvailable(URI minioUri) throws IOException {
-        var httpClient = testHttpClient();
-        var healthRq = new Request.Builder().url(minioUri + "/minio/health/live").get().build();
-        try (var response = httpClient.execute(healthRq)) {
-            return response.isSuccessful();
-        }
-    }
-
     @BeforeEach
     public void setupClients() {
-        s3AsyncSourceClient = sourceClientProvider.s3AsyncClient(REGION);
-        s3AsyncDestinationClient = destinationClientProvider.s3AsyncClient(REGION);
-        createBucket(bucketName, MinioInstance.SOURCE);
+        sourceClient.createBucket(bucketName);
     }
 
     @AfterEach
     void cleanup() {
-        deleteBucket(bucketName, MinioInstance.SOURCE);
-    }
-
-    @NotNull
-    protected String createBucketName() {
-        return "test-bucket-" + processId + "-" + REGION;
-    }
-
-    protected void createBucket(String bucketName, MinioInstance minioInstance) {
-        if (bucketExists(bucketName, minioInstance)) {
-            fail("Bucket " + bucketName + " exists. Choose a different bucket name to continue test");
-        }
-
-        getMinioClient(minioInstance).createBucket(CreateBucketRequest.builder().bucket(bucketName).build()).join();
-
-        if (!bucketExists(bucketName, minioInstance)) {
-            fail("Setup incomplete, tests will fail");
-        }
-    }
-
-    protected void deleteBucket(String bucketName, MinioInstance minioInstance) {
-
-        S3AsyncClient s3AsyncClient = getMinioClient(minioInstance);
-
-        try {
-            if (s3AsyncClient == null) {
-                return;
-            }
-
-            // Empty the bucket before deleting it, otherwise the AWS S3 API fails
-            deleteBucketObjects(bucketName, minioInstance);
-
-            s3AsyncClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build()).join();
-        } catch (Exception e) {
-            System.err.println("Unable to delete bucket " + bucketName + e);
-        }
-
-        if (bucketExists(bucketName, minioInstance)) {
-            fail("Incomplete teardown, subsequent tests might fail");
-        }
-    }
-
-    protected CompletableFuture<PutObjectResponse> putTestFile(String key, File file, String bucketName, MinioInstance minioInstance) {
-        return getMinioClient(minioInstance).putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(), file.toPath());
-    }
-
-    protected void putStringOnBucket(String bucketName, String key, String content, MinioInstance minioInstance) {
-        var request = PutObjectRequest.builder().bucket(bucketName).key(key).build();
-        var response = getMinioClient(minioInstance).putObject(request, AsyncRequestBody.fromString(content));
-        assertThat(response).succeedsWithin(10, TimeUnit.SECONDS);
-    }
-
-    protected @NotNull AwsCredentials getSourceCredentials() {
-        var profile = propOrEnv("it.aws.profile", null);
-        if (profile != null) {
-            return ProfileCredentialsProvider.create(profile).resolveCredentials();
-        }
-
-        var accessKeyId = propOrEnv("S3_ACCESS_KEY_ID_SOURCE", "root");
-        Objects.requireNonNull(accessKeyId, "S3_ACCESS_KEY_ID_SOURCE cannot be null!");
-        var secretKey = propOrEnv("S3_SECRET_ACCESS_KEY_SOURCE", "password");
-        Objects.requireNonNull(secretKey, "S3_SECRET_ACCESS_KEY_SOURCE cannot be null");
-
-        return AwsBasicCredentials.create(accessKeyId, secretKey);
-    }
-
-    protected @NotNull AwsCredentials getDestinationCredentials() {
-        var profile = propOrEnv("it.aws.profile", null);
-        if (profile != null) {
-            return ProfileCredentialsProvider.create(profile).resolveCredentials();
-        }
-
-        var accessKeyId = propOrEnv("S3_ACCESS_KEY_ID_DESTINATION", "root");
-        Objects.requireNonNull(accessKeyId, "S3_ACCESS_KEY_ID_DESTINATION cannot be null!");
-        var secretKey = propOrEnv("S3_SECRET_ACCESS_KEY_DESTINATION", "password");
-        Objects.requireNonNull(secretKey, "S3_SECRET_ACCESS_KEY_DESTINATION cannot be null");
-
-        return AwsBasicCredentials.create(accessKeyId, secretKey);
-    }
-
-    private void deleteBucketObjects(String bucketName, MinioInstance minioInstance) {
-        S3AsyncClient s3AsyncClient = getMinioClient(minioInstance);
-
-        var objectListing = s3AsyncClient.listObjects(ListObjectsRequest.builder().bucket(bucketName).build()).join();
-
-        CompletableFuture.allOf(objectListing.contents().stream()
-            .map(object -> s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(object.key()).build()))
-            .toArray(CompletableFuture[]::new)).join();
-
-        for (var objectSummary : objectListing.contents()) {
-            s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(objectSummary.key()).build()).join();
-        }
-
-        if (objectListing.isTruncated()) {
-            deleteBucketObjects(bucketName, minioInstance);
-        }
-    }
-
-    private boolean bucketExists(String bucketName, MinioInstance minioInstance) {
-        try {
-            HeadBucketRequest request = HeadBucketRequest.builder().bucket(bucketName).build();
-            return getMinioClient(minioInstance).headBucket(request).join()
-                .sdkHttpResponse()
-                .isSuccessful();
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof NoSuchBucketException) {
-                return false;
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    protected S3AsyncClient getMinioClient(MinioInstance minio) {
-        return minio.equals(MinioInstance.SOURCE) ? s3AsyncSourceClient : s3AsyncDestinationClient;
-    }
-
-    public enum MinioInstance {
-        SOURCE,
-        DESTINATION;
+        sourceClient.deleteBucket(bucketName);
     }
 }
-

--- a/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
+++ b/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
@@ -15,9 +15,6 @@
 
 package org.eclipse.edc.aws.s3.testfixtures;
 
-import java.io.File;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import okhttp3.Request;
 import org.eclipse.edc.aws.s3.AwsClientProvider;
 import org.eclipse.edc.aws.s3.AwsClientProviderConfiguration;
@@ -39,15 +36,18 @@ import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -81,14 +81,14 @@ public abstract class AbstractS3Test {
 
     protected String bucketName = createBucketName();
     private final AwsClientProviderConfiguration sourceConfiguration = AwsClientProviderConfiguration.Builder.newInstance()
-        .credentialsProvider(this::getSourceCredentials)
-        .endpointOverride(SOURCE_S3_ENDPOINT)
-        .build();
+            .credentialsProvider(this::getSourceCredentials)
+            .endpointOverride(SOURCE_S3_ENDPOINT)
+            .build();
 
     private final AwsClientProviderConfiguration destinationConfiguration = AwsClientProviderConfiguration.Builder.newInstance()
-        .credentialsProvider(this::getDestinationCredentials)
-        .endpointOverride(DESTINATION_S3_ENDPOINT)
-        .build();
+            .credentialsProvider(this::getDestinationCredentials)
+            .endpointOverride(DESTINATION_S3_ENDPOINT)
+            .build();
     protected AwsClientProvider sourceClientProvider = new AwsClientProviderImpl(sourceConfiguration);
 
     protected AwsClientProvider destinationClientProvider = new AwsClientProviderImpl(destinationConfiguration);
@@ -251,9 +251,11 @@ public abstract class AbstractS3Test {
             }
         }
     }
+
     protected S3AsyncClient getMinioClient(MinioInstance minio) {
         return minio.equals(MinioInstance.SOURCE) ? s3AsyncSourceClient : s3AsyncDestinationClient;
     }
+
     public enum MinioInstance {
         SOURCE,
         DESTINATION;

--- a/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/S3TestClient.java
+++ b/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/S3TestClient.java
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (c) 2023 ZF Friedrichshafen AG
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       ZF Friedrichshafen AG - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3.testfixtures;
+
+import okhttp3.Request;
+import org.eclipse.edc.aws.s3.AwsClientProvider;
+import org.eclipse.edc.aws.s3.AwsClientProviderConfiguration;
+import org.eclipse.edc.aws.s3.AwsClientProviderImpl;
+import org.jetbrains.annotations.NotNull;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.internal.async.ByteArrayAsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.testHttpClient;
+import static org.eclipse.edc.util.configuration.ConfigurationFunctions.propOrEnv;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class S3TestClient {
+
+    private final String url;
+
+    private final URI s3Endpoint;
+
+    private final S3AsyncClient s3AsyncClient;
+
+    private final AwsClientProvider clientProvider;
+
+    private S3TestClient(String url, String region) {
+        this.url = url;
+        this.s3Endpoint = URI.create(propOrEnv("it.aws.endpoint", url));
+        AwsClientProviderConfiguration configuration = AwsClientProviderConfiguration.Builder.newInstance()
+                .credentialsProvider(this::getCredentials)
+                .endpointOverride(this.s3Endpoint)
+                .build();
+        this.clientProvider = new AwsClientProviderImpl(configuration);
+        this.s3AsyncClient = clientProvider.s3AsyncClient(region);
+    }
+
+    public static S3TestClient create(String url, String region) {
+        return new S3TestClient(url, region);
+    }
+
+    public @NotNull AwsCredentials getCredentials() {
+        var profile = propOrEnv("it.aws.profile", null);
+        if (profile != null) {
+            return ProfileCredentialsProvider.create(profile).resolveCredentials();
+        }
+
+        var accessKeyId = propOrEnv("S3_ACCESS_KEY_ID", "root");
+        Objects.requireNonNull(accessKeyId, "S3_ACCESS_KEY_ID cannot be null!");
+        var secretKey = propOrEnv("S3_SECRET_ACCESS_KEY", "password");
+        Objects.requireNonNull(secretKey, "S3_SECRET_ACCESS_KEY cannot be null");
+
+        return AwsBasicCredentials.create(accessKeyId, secretKey);
+    }
+
+    /**
+     * pings <a href="https://docs.min.io/minio/baremetal/monitoring/healthcheck-probe.html">MinIO's health endpoint</a>
+     *
+     * @return true if HTTP status [200..300[
+     */
+    protected boolean isAvailable()  throws IOException {
+        var httpClient = testHttpClient();
+        var healthRq = new Request.Builder().url(s3Endpoint + "/minio/health/live").get().build();
+        try (var response = httpClient.execute(healthRq)) {
+            return response.isSuccessful();
+        }
+    }
+
+    public void createBucket(String bucketName) {
+        if (bucketExists(bucketName)) {
+            fail("Bucket " + bucketName + " exists. Choose a different bucket name to continue test");
+        }
+
+        s3AsyncClient.createBucket(CreateBucketRequest.builder().bucket(bucketName).build()).join();
+
+        if (!bucketExists(bucketName)) {
+            fail("Setup incomplete, tests will fail");
+        }
+    }
+
+    private boolean bucketExists(String bucketName) {
+        try {
+            HeadBucketRequest request = HeadBucketRequest.builder().bucket(bucketName).build();
+            return s3AsyncClient.headBucket(request).join()
+                   .sdkHttpResponse()
+                   .isSuccessful();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof NoSuchBucketException) {
+                return false;
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public void deleteBucket(String bucketName) {
+        try {
+            if (s3AsyncClient == null) {
+                return;
+            }
+
+            // Empty the bucket before deleting it, otherwise the AWS S3 API fails
+            deleteBucketObjects(bucketName);
+
+            s3AsyncClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build()).join();
+        } catch (Exception e) {
+            System.err.println("Unable to delete bucket " + bucketName + e);
+        }
+
+        if (bucketExists(bucketName)) {
+            fail("Incomplete teardown, subsequent tests might fail");
+        }
+    }
+
+    private void deleteBucketObjects(String bucketName) {
+        var objectListing = s3AsyncClient.listObjects(ListObjectsRequest.builder().bucket(bucketName).build()).join();
+
+        CompletableFuture.allOf(objectListing.contents().stream()
+              .map(object -> s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(object.key()).build()))
+              .toArray(CompletableFuture[]::new)).join();
+
+        for (var objectSummary : objectListing.contents()) {
+            s3AsyncClient.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(objectSummary.key()).build()).join();
+        }
+
+        if (objectListing.isTruncated()) {
+            deleteBucketObjects(bucketName);
+        }
+    }
+
+    public void putStringOnBucket(String bucketName, String key, String content) {
+        var request = PutObjectRequest.builder().bucket(bucketName).key(key).build();
+        var response = s3AsyncClient.putObject(request, AsyncRequestBody.fromString(content));
+        assertThat(response).succeedsWithin(10, TimeUnit.SECONDS);
+    }
+
+    public void putTestFile(String key, File file, String bucketName) {
+        s3AsyncClient.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(), file.toPath());
+    }
+
+    public CompletableFuture<ResponseBytes<GetObjectResponse>> getObject(String bucketName, String key) {
+        return s3AsyncClient
+             .getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(), new ByteArrayAsyncResponseTransformer<>());
+    }
+
+    protected boolean isMinio() {
+        return url.equals(s3Endpoint.toString());
+    }
+
+    public AwsClientProvider getClientProvider() {
+        return clientProvider;
+    }
+
+    public S3AsyncClient getS3AsyncClient() {
+        return s3AsyncClient;
+    }
+}

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
@@ -49,7 +49,7 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
     void setup() {
         var retryPolicy = RetryPolicy.builder().withMaxRetries(3).withBackoff(200, 1000, ChronoUnit.MILLIS).build();
         var providerMock = mock(AwsClientProvider.class);
-        when(providerMock.s3AsyncClient(anyString())).thenReturn(s3AsyncClient);
+        when(providerMock.s3AsyncClient(anyString())).thenReturn(s3AsyncSourceClient);
         checker = new S3StatusChecker(providerMock, retryPolicy);
     }
 
@@ -62,7 +62,7 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
 
     @Test
     void isComplete_noResources_whenComplete() throws InterruptedException {
-        putTestFile(PROCESS_ID + ".complete", getFileFromResourceName("hello.txt"), bucketName);
+        putTestFile(PROCESS_ID + ".complete", getFileFromResourceName("hello.txt"), bucketName, MinioInstance.SOURCE);
         var transferProcess = createTransferProcess(bucketName);
 
         var hasCompleted = waitUntil(() -> checker.isComplete(transferProcess, emptyList()), ONE_MINUTE_MILLIS);
@@ -89,7 +89,7 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
 
     @Test
     void isComplete_withResources_whenComplete() throws InterruptedException {
-        putTestFile(PROCESS_ID + ".complete", getFileFromResourceName("hello.txt"), bucketName);
+        putTestFile(PROCESS_ID + ".complete", getFileFromResourceName("hello.txt"), bucketName, MinioInstance.SOURCE);
         TransferProcess tp = createTransferProcess(bucketName);
 
         var hasCompleted = waitUntil(() -> checker.isComplete(tp, emptyList()), ONE_MINUTE_MILLIS);
@@ -125,27 +125,27 @@ class S3StatusCheckerIntegrationTest extends AbstractS3Test {
 
     private S3BucketProvisionedResource createProvisionedResource(TransferProcess transferProcess) {
         return S3BucketProvisionedResource.Builder.newInstance()
-                .bucketName(bucketName)
-                .region(REGION)
-                .resourceDefinitionId(UUID.randomUUID().toString())
-                .transferProcessId(transferProcess.getId())
-                .id(UUID.randomUUID().toString())
-                .resourceName(bucketName)
-                .build();
+            .bucketName(bucketName)
+            .region(REGION)
+            .resourceDefinitionId(UUID.randomUUID().toString())
+            .transferProcessId(transferProcess.getId())
+            .id(UUID.randomUUID().toString())
+            .resourceName(bucketName)
+            .build();
     }
 
     private TransferProcess createTransferProcess(String bucketName) {
         return TransferProcess.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .dataRequest(DataRequest.Builder.newInstance()
-                        .destinationType(S3BucketSchema.TYPE)
-                        .dataDestination(DataAddress.Builder.newInstance()
-                                .type(S3BucketSchema.TYPE)
-                                .property(S3BucketSchema.REGION, AbstractS3Test.REGION)
-                                .property(S3BucketSchema.BUCKET_NAME, bucketName)
-                                .build())
-                        .build())
-                .build();
+            .id(UUID.randomUUID().toString())
+            .dataRequest(DataRequest.Builder.newInstance()
+                .destinationType(S3BucketSchema.TYPE)
+                .dataDestination(DataAddress.Builder.newInstance()
+                    .type(S3BucketSchema.TYPE)
+                    .property(S3BucketSchema.REGION, AbstractS3Test.REGION)
+                    .property(S3BucketSchema.BUCKET_NAME, bucketName)
+                    .build())
+                .build())
+            .build();
     }
 
 

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3StatusCheckerIntegrationTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       ZF Friedrichshafen AG
  *
  */
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
@@ -105,7 +105,7 @@ public class S3DataSinkFactory implements DataSinkFactory {
             client = clientProvider.s3Client(destination.getStringProperty(REGION), secretToken);
         } else if (credentialsValidation.apply(destination).succeeded()) {
             var secretToken = new AwsSecretToken(destination.getStringProperty(ACCESS_KEY_ID),
-                destination.getStringProperty(SECRET_ACCESS_KEY));
+                    destination.getStringProperty(SECRET_ACCESS_KEY));
             client = clientProvider.s3Client(destination.getStringProperty(REGION), secretToken);
         } else {
             client = clientProvider.s3Client(destination.getStringProperty(REGION));

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       ZF Friedrichshafen AG - Initial implementation
  *
  */
 

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -72,30 +72,30 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
         var sinkFactory = new S3DataSinkFactory(destinationClientProvider, Executors.newSingleThreadExecutor(), mock(Monitor.class), vault, typeManager);
         var sourceFactory = new S3DataSourceFactory(sourceClientProvider, vault, typeManager);
         var sourceAddress = DataAddress.Builder.newInstance()
-            .type(S3BucketSchema.TYPE)
-            .keyName(key)
-            .property(BUCKET_NAME, sourceBucketName)
-            .property(S3BucketSchema.REGION, REGION)
-            .property(ACCESS_KEY_ID, getSourceCredentials().accessKeyId())
-            .property(SECRET_ACCESS_KEY, getSourceCredentials().secretAccessKey())
-            .build();
+                .type(S3BucketSchema.TYPE)
+                .keyName(key)
+                .property(BUCKET_NAME, sourceBucketName)
+                .property(S3BucketSchema.REGION, REGION)
+                .property(ACCESS_KEY_ID, getSourceCredentials().accessKeyId())
+                .property(SECRET_ACCESS_KEY, getSourceCredentials().secretAccessKey())
+                .build();
 
         var destinationAddress = DataAddress.Builder.newInstance()
-            .type(S3BucketSchema.TYPE)
-            .keyName(key)
-            .property(BUCKET_NAME, destinationBucketName)
-            .property(S3BucketSchema.REGION, REGION)
-            .property(ACCESS_KEY_ID, getDestinationCredentials().accessKeyId())
-            .property(SECRET_ACCESS_KEY, getDestinationCredentials().secretAccessKey())
-            .property(ENDPOINT_OVERRIDE, DESTINATION_MINIO_ENDPOINT)
-            .build();
+                .type(S3BucketSchema.TYPE)
+                .keyName(key)
+                .property(BUCKET_NAME, destinationBucketName)
+                .property(S3BucketSchema.REGION, REGION)
+                .property(ACCESS_KEY_ID, getDestinationCredentials().accessKeyId())
+                .property(SECRET_ACCESS_KEY, getDestinationCredentials().secretAccessKey())
+                .property(ENDPOINT_OVERRIDE, DESTINATION_MINIO_ENDPOINT)
+                .build();
 
         var request = DataFlowRequest.Builder.newInstance()
-            .id(UUID.randomUUID().toString())
-            .processId(UUID.randomUUID().toString())
-            .sourceDataAddress(sourceAddress)
-            .destinationDataAddress(destinationAddress)
-            .build();
+                .id(UUID.randomUUID().toString())
+                .processId(UUID.randomUUID().toString())
+                .sourceDataAddress(sourceAddress)
+                .destinationDataAddress(destinationAddress)
+                .build();
 
         var sink = sinkFactory.createSink(request);
         var source = sourceFactory.createSource(request);

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       ZF Friedrichshafen AG
  *
  */
 
@@ -18,6 +19,7 @@ import org.eclipse.edc.aws.s3.AwsClientProvider;
 import org.eclipse.edc.aws.s3.AwsSecretToken;
 import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
+import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
@@ -30,6 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -39,8 +42,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.REGION;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,6 +52,7 @@ class S3DataSinkFactoryTest {
     private final Vault vault = mock(Vault.class);
     private final TypeManager typeManager = new TypeManager();
     private final S3DataSinkFactory factory = new S3DataSinkFactory(clientProvider, mock(ExecutorService.class), mock(Monitor.class), vault, typeManager);
+    private final ArgumentCaptor<S3ClientRequest> s3ClientRequestArgumentCaptor = ArgumentCaptor.forClass(S3ClientRequest.class);
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {
@@ -108,7 +110,14 @@ class S3DataSinkFactoryTest {
         var sink = factory.createSink(request);
 
         assertThat(sink).isNotNull().isInstanceOf(S3DataSink.class);
-        verify(clientProvider).s3Client(eq(TestFunctions.VALID_REGION), isA(AwsTemporarySecretToken.class));
+
+        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
+
+        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
+
+        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.getSecretToken()).isInstanceOf(AwsTemporarySecretToken.class);
+        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
     }
 
     @Test
@@ -120,7 +129,14 @@ class S3DataSinkFactoryTest {
         var sink = factory.createSink(request);
 
         assertThat(sink).isNotNull().isInstanceOf(S3DataSink.class);
-        verify(clientProvider).s3Client(TestFunctions.VALID_REGION, new AwsSecretToken(TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY));
+
+        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
+
+        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
+
+        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.getSecretToken()).isEqualTo(new AwsSecretToken(TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY));
+        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
     }
 
     @Test
@@ -132,7 +148,14 @@ class S3DataSinkFactoryTest {
         var sink = factory.createSink(request);
 
         assertThat(sink).isNotNull().isInstanceOf(S3DataSink.class);
-        verify(clientProvider).s3Client(TestFunctions.VALID_REGION);
+
+        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
+
+        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
+
+        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.getSecretToken()).isNull();
+        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
     }
 
     @Test
@@ -149,7 +172,7 @@ class S3DataSinkFactoryTest {
     private static class InvalidInputs implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
                     Arguments.of(TestFunctions.VALID_BUCKET_NAME, " ", TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY),
                     Arguments.of(" ", TestFunctions.VALID_REGION, TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
@@ -115,9 +115,9 @@ class S3DataSinkFactoryTest {
 
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
-        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.getSecretToken()).isInstanceOf(AwsTemporarySecretToken.class);
-        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsTemporarySecretToken.class);
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     @Test
@@ -134,9 +134,9 @@ class S3DataSinkFactoryTest {
 
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
-        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.getSecretToken()).isEqualTo(new AwsSecretToken(TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY));
-        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isEqualTo(new AwsSecretToken(TestFunctions.VALID_ACCESS_KEY_ID, TestFunctions.VALID_SECRET_ACCESS_KEY));
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     @Test
@@ -153,9 +153,9 @@ class S3DataSinkFactoryTest {
 
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
-        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.getSecretToken()).isNull();
-        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isNull();
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     @Test

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -124,9 +124,9 @@ class S3DataSourceFactoryTest {
 
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
-        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.getSecretToken()).isNull();
-        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isNull();
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     @Test
@@ -155,9 +155,9 @@ class S3DataSourceFactoryTest {
 
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
-        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.getSecretToken()).isInstanceOf(AwsSecretToken.class);
-        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsSecretToken.class);
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     private DataFlowRequest createRequest(DataAddress source) {

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *       ZF Friedrichshafen AG - Initial implementation
  *
  */
 
@@ -17,6 +18,7 @@ package org.eclipse.edc.connector.dataplane.aws.s3;
 import org.eclipse.edc.aws.s3.AwsClientProvider;
 import org.eclipse.edc.aws.s3.AwsSecretToken;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
+import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -28,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -40,8 +43,6 @@ import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_REG
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_SECRET_ACCESS_KEY;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.s3DataAddressWithCredentials;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.s3DataAddressWithoutCredentials;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,8 +52,8 @@ class S3DataSourceFactoryTest {
     private final AwsClientProvider clientProvider = mock(AwsClientProvider.class);
     private final TypeManager typeManager = new TypeManager();
     private final Vault vault = mock(Vault.class);
-
     private final S3DataSourceFactory factory = new S3DataSourceFactory(clientProvider, vault, typeManager);
+    private final ArgumentCaptor<S3ClientRequest> s3ClientRequestArgumentCaptor = ArgumentCaptor.forClass(S3ClientRequest.class);
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {
@@ -118,7 +119,14 @@ class S3DataSourceFactoryTest {
         var sink = factory.createSource(request);
 
         assertThat(sink).isNotNull().isInstanceOf(S3DataSource.class);
-        verify(clientProvider).s3Client(VALID_REGION);
+
+        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
+
+        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
+
+        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.getSecretToken()).isNull();
+        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
     }
 
     @Test
@@ -142,7 +150,14 @@ class S3DataSourceFactoryTest {
         var s3Source = factory.createSource(request);
 
         assertThat(s3Source).isNotNull().isInstanceOf(S3DataSource.class);
-        verify(clientProvider).s3Client(eq(TestFunctions.VALID_REGION), isA(AwsSecretToken.class));
+
+        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
+
+        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
+
+        assertThat(s3ClientRequest.getRegion()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.getSecretToken()).isInstanceOf(AwsSecretToken.class);
+        assertThat(s3ClientRequest.getEndpointOverride()).isNull();
     }
 
     private DataFlowRequest createRequest(DataAddress source) {


### PR DESCRIPTION
## What this PR changes/adds

PR adds possibility to specify 'endpointOverride' property in DataAddress.

## Why it does that

So that it's possible to push data into different instance of S3 compatible storage than configured via dataplane's properties.

## Further notes

Change mostly based on previous PR (https://github.com/eclipse-edc/Connector/pull/1904) by @reisman234, recreated due to changes in project structure.

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Technology-Aws/issues/24
