### PR TITLE
feat: enable reusable credentials for S3 integration

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -12,9 +12,9 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
-maven/mavencentral/com.github.docker-java/docker-java-api/3.3.4, Apache-2.0, approved, #10346
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
-maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.4, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.5, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
@@ -27,7 +27,7 @@ maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, ap
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, , restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -65,9 +65,10 @@ maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-onl
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
@@ -208,8 +209,8 @@ maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.2, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
+maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
-maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
 maven/mavencentral/org.mockito/mockito-inline/5.2.0, MIT, approved, clearlydefined
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
@@ -226,15 +227,15 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.5, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/testcontainers/1.19.5, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.6, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/testcontainers/1.19.6, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/annotations/2.24.10, Apache-2.0, approved, #13251
 maven/mavencentral/software.amazon.awssdk/apache-client/2.24.10, Apache-2.0, approved, #13257
 maven/mavencentral/software.amazon.awssdk/arns/2.24.10, Apache-2.0, approved, #13243
 maven/mavencentral/software.amazon.awssdk/auth/2.24.10, Apache-2.0, approved, #13256
 maven/mavencentral/software.amazon.awssdk/aws-core/2.24.10, Apache-2.0, approved, #13240
-maven/mavencentral/software.amazon.awssdk/aws-json-protocol/2.24.10, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/aws-json-protocol/2.24.10, Apache-2.0, approved, #13445
 maven/mavencentral/software.amazon.awssdk/aws-query-protocol/2.24.10, Apache-2.0, approved, #13262
 maven/mavencentral/software.amazon.awssdk/aws-xml-protocol/2.24.10, Apache-2.0, approved, #13247
 maven/mavencentral/software.amazon.awssdk/checksums-spi/2.24.10, Apache-2.0, approved, #13245
@@ -245,7 +246,7 @@ maven/mavencentral/software.amazon.awssdk/http-auth-aws/2.24.10, Apache-2.0, app
 maven/mavencentral/software.amazon.awssdk/http-auth-spi/2.24.10, Apache-2.0, approved, #13264
 maven/mavencentral/software.amazon.awssdk/http-auth/2.24.10, Apache-2.0, approved, #13248
 maven/mavencentral/software.amazon.awssdk/http-client-spi/2.24.10, Apache-2.0, approved, #13259
-maven/mavencentral/software.amazon.awssdk/iam/2.24.10, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/iam/2.24.10, Apache-2.0, approved, #13444
 maven/mavencentral/software.amazon.awssdk/identity-spi/2.24.10, Apache-2.0, approved, #13244
 maven/mavencentral/software.amazon.awssdk/json-utils/2.24.10, Apache-2.0, approved, #13261
 maven/mavencentral/software.amazon.awssdk/metrics-spi/2.24.10, Apache-2.0, approved, #13239
@@ -255,8 +256,8 @@ maven/mavencentral/software.amazon.awssdk/protocol-core/2.24.10, Apache-2.0, app
 maven/mavencentral/software.amazon.awssdk/regions/2.24.10, Apache-2.0, approved, #13255
 maven/mavencentral/software.amazon.awssdk/s3/2.24.10, Apache-2.0, approved, #13254
 maven/mavencentral/software.amazon.awssdk/sdk-core/2.24.10, Apache-2.0, approved, #13265
-maven/mavencentral/software.amazon.awssdk/secretsmanager/2.24.10, , restricted, clearlydefined
-maven/mavencentral/software.amazon.awssdk/sts/2.24.10, , restricted, clearlydefined
+maven/mavencentral/software.amazon.awssdk/secretsmanager/2.24.10, Apache-2.0, approved, #13443
+maven/mavencentral/software.amazon.awssdk/sts/2.24.10, Apache-2.0, approved, #13442
 maven/mavencentral/software.amazon.awssdk/third-party-jackson-core/2.24.10, Apache-2.0, approved, #13249
 maven/mavencentral/software.amazon.awssdk/utils/2.24.10, Apache-2.0, approved, #13250
 maven/mavencentral/software.amazon.eventstream/eventstream/1.0.1, Apache-2.0, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,30 +4,29 @@ maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, 
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.2, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.1, Apache-2.0, approved, #11856
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approved, #11852
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.2, Apache-2.0, approved, #11856
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.2, Apache-2.0, approved, #11852
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.23.0, Apache-2.0, approved, #11083
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657
 maven/mavencentral/com.google.guava/failureaccess/1.0.2, Apache-2.0, approved, CQ22654
-maven/mavencentral/com.google.guava/guava/33.0.0-jre, Apache-2.0 AND CC0-1.0, approved, #12173
+maven/mavencentral/com.google.guava/guava/33.1.0-jre, Apache-2.0 AND CC0-1.0, approved, #13675
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.2, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #13562
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.9.3, Apache-2.0 AND MPL-2.0, approved, #3225
@@ -58,8 +57,8 @@ maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, ap
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
-maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
+maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, ee4j.cdi
+maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jta
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
@@ -93,7 +92,6 @@ maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearl
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
-maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
 maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -99,6 +99,7 @@ maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/boot-lib/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/catalog-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/connector-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -110,6 +111,7 @@ maven/mavencentral/org.eclipse.edc/crypto-common/0.5.2-SNAPSHOT, Apache-2.0, app
 maven/mavencentral/org.eclipse.edc/data-plane-core/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/data-plane-util/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/http-lib/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/http/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-did-spi/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
@@ -19,11 +19,10 @@ public interface S3BucketSchema {
     String TYPE = "AmazonS3";
     String REGION = "region";
     String BUCKET_NAME = "bucketName";
-    String KEY_NAME = "keyName";
-    String KEY_PREFIX = "keyPrefix";
     String FOLDER_NAME = "folderName";
     String ACCESS_KEY_ID = "accessKeyId";
     String SECRET_ACCESS_KEY = "secretAccessKey";
     String ENDPOINT_OVERRIDE = "endpointOverride";
-    String SECRET_TOKEN = "secretToken";
+    String OBJECT_PREFIX = "objectPrefix";
+    String OBJECT_NAME = "objectName";
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3BucketSchema.java
@@ -23,6 +23,10 @@ public interface S3BucketSchema {
     String ACCESS_KEY_ID = "accessKeyId";
     String SECRET_ACCESS_KEY = "secretAccessKey";
     String ENDPOINT_OVERRIDE = "endpointOverride";
+    @Deprecated(since = "0.5.2")
+    String KEY_PREFIX = "keyPrefix";
     String OBJECT_PREFIX = "objectPrefix";
+    @Deprecated(since = "0.5.2")
+    String KEY_NAME = "keyName";
     String OBJECT_NAME = "objectName";
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3DataAddressValidatorExtension.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/S3DataAddressValidatorExtension.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.edc.aws.s3;
 
-import org.eclipse.edc.aws.s3.validation.S3DataAddressValidator;
+import org.eclipse.edc.aws.s3.validation.S3DestinationDataAddressValidator;
+import org.eclipse.edc.aws.s3.validation.S3SourceDataAddressValidator;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -37,8 +38,9 @@ public class S3DataAddressValidatorExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var validator = new S3DataAddressValidator();
-        validatorRegistry.registerDestinationValidator(S3BucketSchema.TYPE, validator);
-        validatorRegistry.registerSourceValidator(S3BucketSchema.TYPE, validator);
+        var sourceValidator = new S3SourceDataAddressValidator();
+        var destinationValidator = new S3DestinationDataAddressValidator();
+        validatorRegistry.registerSourceValidator(S3BucketSchema.TYPE, sourceValidator);
+        validatorRegistry.registerDestinationValidator(S3BucketSchema.TYPE, destinationValidator);
     }
 }

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/validation/S3DestinationDataAddressValidator.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/validation/S3DestinationDataAddressValidator.java
@@ -28,7 +28,7 @@ import static org.eclipse.edc.validator.spi.Violation.violation;
 /**
  * Validator for AmazonS3 DataAddress type
  */
-public class S3DataAddressValidator implements Validator<DataAddress> {
+public class S3DestinationDataAddressValidator implements Validator<DataAddress> {
 
     @Override
     public ValidationResult validate(DataAddress dataAddress) {

--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/validation/S3SourceDataAddressValidator.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/validation/S3SourceDataAddressValidator.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3.validation;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.KEY_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.KEY_PREFIX;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_PREFIX;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.REGION;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+/**
+ * Validator for AmazonS3 DataAddress type
+ */
+public class S3SourceDataAddressValidator implements Validator<DataAddress> {
+
+    @Override
+    public ValidationResult validate(DataAddress dataAddress) {
+        var violations = new ArrayList<Violation>();
+
+        Stream.of(BUCKET_NAME, REGION).forEach(it -> {
+            var value = dataAddress.getStringProperty(it);
+            if (value == null || value.isBlank()) {
+                violations.add(violation("'%s' is a mandatory attribute".formatted(it), it, value));
+            }
+        });
+
+        if (Stream.of(OBJECT_NAME, KEY_NAME, OBJECT_PREFIX, KEY_PREFIX)
+                .map(dataAddress::getStringProperty)
+                .allMatch(it -> (it == null || it.isBlank()))) {
+            violations.add(violation("Either the '%s' or '%s' attribute must be provided."
+                    .formatted(OBJECT_NAME, OBJECT_PREFIX), OBJECT_NAME, null));
+        }
+
+        if (violations.isEmpty()) {
+            return ValidationResult.success();
+        }
+
+        return ValidationResult.failure(violations);
+    }
+
+}

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3DestinationDataAddressValidatorExtensionTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/S3DestinationDataAddressValidatorExtensionTest.java
@@ -15,7 +15,8 @@
 package org.eclipse.edc.aws.s3;
 
 
-import org.eclipse.edc.aws.s3.validation.S3DataAddressValidator;
+import org.eclipse.edc.aws.s3.validation.S3DestinationDataAddressValidator;
+import org.eclipse.edc.aws.s3.validation.S3SourceDataAddressValidator;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
-public class S3DataAddressValidatorExtensionTest {
+public class S3DestinationDataAddressValidatorExtensionTest {
 
     private final DataAddressValidatorRegistry registry = mock();
 
@@ -42,10 +43,9 @@ public class S3DataAddressValidatorExtensionTest {
     @Test
     void initialize(S3DataAddressValidatorExtension extension, ServiceExtensionContext context) {
         extension.initialize(context);
-
         assertThat(extension.name()).isEqualTo(S3DataAddressValidatorExtension.NAME);
+        verify(registry).registerSourceValidator(eq(S3BucketSchema.TYPE), isA(S3SourceDataAddressValidator.class));
+        verify(registry).registerDestinationValidator(eq(S3BucketSchema.TYPE), isA(S3DestinationDataAddressValidator.class));
 
-        verify(registry).registerDestinationValidator(eq(S3BucketSchema.TYPE), isA(S3DataAddressValidator.class));
-        verify(registry).registerSourceValidator(eq(S3BucketSchema.TYPE), isA(S3DataAddressValidator.class));
     }
 }

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/validation/S3DestinationDataAddressValidatorTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/validation/S3DestinationDataAddressValidatorTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3.validation;
+
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.validator.spi.ValidationFailure;
+import org.eclipse.edc.validator.spi.Violation;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.REGION;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.TYPE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+public class S3DestinationDataAddressValidatorTest {
+
+    private final S3DestinationDataAddressValidator validator = new S3DestinationDataAddressValidator();
+
+    @Test
+    void should_pass_when_data_address_is_valid() {
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .property(BUCKET_NAME, "bucketName")
+                .property(REGION, "region")
+                .build();
+
+        var result = validator.validate(dataAddress);
+
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void should_fail_when_required_fields_are_missing() {
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .build();
+
+        var result = validator.validate(dataAddress);
+
+        assertThat(result).isFailed()
+                .extracting(ValidationFailure::getViolations)
+                .satisfies(violations -> assertThat(violations)
+                        .extracting(Violation::path)
+                        .containsExactlyInAnyOrder(BUCKET_NAME, REGION));
+    }
+}

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/validation/S3SourceDataAddressValidatorTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/validation/S3SourceDataAddressValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -21,20 +21,23 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.REGION;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.TYPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
-public class S3DataAddressValidatorTest {
+public class S3SourceDataAddressValidatorTest {
 
-    private final S3DataAddressValidator validator = new S3DataAddressValidator();
+    private final S3SourceDataAddressValidator validator = new S3SourceDataAddressValidator();
 
     @Test
-    void shouldPass_whenDataAddressIsValid() {
+    void should_pass_when_data_address_is_valid_with_object_name() {
         var dataAddress = DataAddress.Builder.newInstance()
                 .type(TYPE)
                 .property(BUCKET_NAME, "bucketName")
                 .property(REGION, "region")
+                .property(OBJECT_NAME, "objectName")
                 .build();
 
         var result = validator.validate(dataAddress);
@@ -43,13 +46,44 @@ public class S3DataAddressValidatorTest {
     }
 
     @Test
-    void shouldFail_whenRequiredFieldsAreMissing() {
+    void should_pass_when_data_address_is_valid_with_object_prefix() {
         var dataAddress = DataAddress.Builder.newInstance()
                 .type(TYPE)
+                .property(BUCKET_NAME, "bucketName")
+                .property(REGION, "region")
+                .property(OBJECT_PREFIX, "objectPrefix")
                 .build();
 
         var result = validator.validate(dataAddress);
 
+        assertThat(result).isSucceeded();
+    }
+
+    @Test
+    void should_fail_when_both_object_name_and_prefix_are_missing() {
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .property(BUCKET_NAME, "bucketName")
+                .property(REGION, "region")
+                .build();
+
+        var result = validator.validate(dataAddress);
+
+        assertThat(result).isFailed()
+                .extracting(ValidationFailure::getViolations)
+                .satisfies(violations -> assertThat(violations)
+                        .extracting(Violation::path)
+                        .contains(OBJECT_NAME));
+    }
+
+    @Test
+    void should_fail_when_region_or_bucketName_is_missing() {
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type(TYPE)
+                .property(OBJECT_NAME, "objectName")
+                .build();
+
+        var result = validator.validate(dataAddress);
 
         assertThat(result).isFailed()
                 .extracting(ValidationFailure::getViolations)

--- a/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
+++ b/extensions/common/aws/aws-s3-test/src/testFixtures/java/org/eclipse/edc/aws/s3/testfixtures/AbstractS3Test.java
@@ -49,9 +49,11 @@ public abstract class AbstractS3Test {
 
     protected S3TestClient destinationClient = S3TestClient.create(DESTINATION_MINIO_ENDPOINT, REGION);
 
-    protected static final String ASSET_PREFIX = "folderName/";
+    protected static final String OBJECT_PREFIX = "object-prefix/";
 
-    protected static final String ASSET_FILE = "text-document.txt";
+    protected static final String OBJECT_NAME = "text-document.txt";
+
+    protected static final String KEY_NAME = "key-name";
 
     @BeforeAll
     void prepareAll() {

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
@@ -46,14 +46,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.EU_WEST_2.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance()
+        var transferProcess = TransferProcess.Builder.newInstance()
                 .dataDestination(destination)
                 .assetId(asset.getId())
                 .correlationId("process-id")
                 .build();
         var policy = Policy.Builder.newInstance().build();
 
-        var definition = generator.generate(dr, policy);
+        var definition = generator.generate(transferProcess, policy);
 
         assertThat(definition).isInstanceOf(S3BucketResourceDefinition.class);
         var objectDef = (S3BucketResourceDefinition) definition;
@@ -74,14 +74,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.BUCKET_NAME, "test-name")
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance()
+        var transferProcess = TransferProcess.Builder.newInstance()
                 .dataDestination(destination)
                 .assetId(asset.getId())
                 .correlationId("process-id")
                 .build();
         var policy = Policy.Builder.newInstance().build();
 
-        var definition = generator.generate(dr, policy);
+        var definition = generator.generate(transferProcess, policy);
 
         assertThat(definition).isInstanceOf(S3BucketResourceDefinition.class);
         var objectDef = (S3BucketResourceDefinition) definition;
@@ -96,14 +96,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.EU_WEST_2.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance()
+        var transferProcess = TransferProcess.Builder.newInstance()
                 .dataDestination(destination)
                 .assetId(asset.getId())
                 .correlationId("process-id")
                 .build();
         var policy = Policy.Builder.newInstance().build();
 
-        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> generator.generate(dr, policy));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> generator.generate(transferProcess, policy));
     }
 
     @Test
@@ -113,14 +113,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.US_EAST_1.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance()
+        var transferProcess = TransferProcess.Builder.newInstance()
                 .dataDestination(destination)
                 .assetId(asset.getId())
                 .correlationId("process-id")
                 .build();
         var policy = Policy.Builder.newInstance().build();
 
-        var definition = generator.canGenerate(dr, policy);
+        var definition = generator.canGenerate(transferProcess, policy);
 
         assertThat(definition).isTrue();
     }
@@ -132,14 +132,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.US_EAST_1.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance()
+        var transferProcess = TransferProcess.Builder.newInstance()
                 .dataDestination(destination)
                 .assetId(asset.getId())
                 .correlationId("process-id")
                 .build();
         var policy = Policy.Builder.newInstance().build();
 
-        var definition = generator.canGenerate(dr, policy);
+        var definition = generator.canGenerate(transferProcess, policy);
         assertThat(definition).isFalse();
     }
 

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.edc.connector.provision.aws.s3;
 
 import org.eclipse.edc.aws.s3.S3BucketSchema;
-import org.eclipse.edc.connector.transfer.spi.types.DataRequest;
 import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -47,7 +46,11 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.EU_WEST_2.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance().dataRequest(DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).processId("process-id").build()).build();
+        var dr = TransferProcess.Builder.newInstance()
+                .dataDestination(destination)
+                .assetId(asset.getId())
+                .correlationId("process-id")
+                .build();
         var policy = Policy.Builder.newInstance().build();
 
         var definition = generator.generate(dr, policy);
@@ -71,7 +74,11 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.BUCKET_NAME, "test-name")
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance().dataRequest(DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).processId("process-id").build()).build();
+        var dr = TransferProcess.Builder.newInstance()
+                .dataDestination(destination)
+                .assetId(asset.getId())
+                .correlationId("process-id")
+                .build();
         var policy = Policy.Builder.newInstance().build();
 
         var definition = generator.generate(dr, policy);
@@ -89,7 +96,11 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.EU_WEST_2.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance().dataRequest(DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).processId("process-id").build()).build();
+        var dr = TransferProcess.Builder.newInstance()
+                .dataDestination(destination)
+                .assetId(asset.getId())
+                .correlationId("process-id")
+                .build();
         var policy = Policy.Builder.newInstance().build();
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> generator.generate(dr, policy));
@@ -102,7 +113,11 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.US_EAST_1.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dr = TransferProcess.Builder.newInstance().dataRequest(DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).processId("process-id").build()).build();
+        var dr = TransferProcess.Builder.newInstance()
+                .dataDestination(destination)
+                .assetId(asset.getId())
+                .correlationId("process-id")
+                .build();
         var policy = Policy.Builder.newInstance().build();
 
         var definition = generator.canGenerate(dr, policy);
@@ -117,10 +132,14 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
                 .property(S3BucketSchema.REGION, Region.US_EAST_1.id())
                 .build();
         var asset = Asset.Builder.newInstance().build();
-        var dataRequest = TransferProcess.Builder.newInstance().dataRequest(DataRequest.Builder.newInstance().dataDestination(destination).assetId(asset.getId()).build()).build();
+        var dr = TransferProcess.Builder.newInstance()
+                .dataDestination(destination)
+                .assetId(asset.getId())
+                .correlationId("process-id")
+                .build();
         var policy = Policy.Builder.newInstance().build();
 
-        var definition = generator.canGenerate(dataRequest, policy);
+        var definition = generator.canGenerate(dr, policy);
         assertThat(definition).isFalse();
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -6,22 +6,22 @@ This module contains a Data Plane extension to copy data to and from Aws S3.
 
 When as a source, it supports copying a single or multiple objects.
 
-### Configuration
+### DataAddress Schema
 
 #### Properties
 
-| Key                | Description                                                            | Applies at              | Mandatory               |
-|:-------------------|:-----------------------------------------------------------------------|-------------------------|-------------------------|
-| `type`             | Defines the Asset type ( `AmazonS3` )                                  | `source`, `destination` | `true`                  |
-| `region`           | Defines the region of the bucket (`us-east-1`, `eu-west-1` ...)        | `source`, `destination` | `true`                  |
-| `endpointOverride` | Defines a custom endpoint URL                                          | `source`, `destination` | `false`                 |
-| `bucketName`       | Defines the name of the S3 bucket                                      | `source`, `destination` | `true`                  |
-| `objectName`       | Defines the name of the S3 object                                      | `source`, `destination` | `true` (only in source) |
-| `objectPrefix`     | Defines the prefix of the S3 objects to be fetched ( `objectPrefix/` ) | `source`                | `false`                 |
-| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `destination`           | `false`                 |
-| `keyName`          | Defines the `vault` entry containing the secret token/credentials      | `source`, `destination` | `false`                 |
-| `accessKeyId`      | Defines the access key id to access S3 Bucket/Object                   | `source`, `destination` | `false`                 |
-| `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object            | `source`, `destination` | `false`                 |
+| Key                | Description                                                            | Applies at              | Mandatory                                             |
+|:-------------------|:-----------------------------------------------------------------------|-------------------------|-------------------------------------------------------|
+| `type`             | Defines the Asset type ( `AmazonS3` )                                  | `source`, `destination` | `true`                                                |
+| `region`           | Defines the region of the bucket (`us-east-1`, `eu-west-1` ...)        | `source`, `destination` | `true`                                                |
+| `endpointOverride` | Defines a custom endpoint URL                                          | `source`, `destination` | `false`                                               |
+| `bucketName`       | Defines the name of the S3 bucket                                      | `source`, `destination` | `true`                                                |
+| `objectName`       | Defines the name of the S3 object                                      | `source`, `destination` | `true` (in `source` if `objectPrefix` is not present) |
+| `objectPrefix`     | Defines the prefix of the S3 objects to be fetched ( `objectPrefix/` ) | `source`                | `true` (if `objectName` is not present)               |
+| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `destination`           | `false`                                               |
+| `keyName`          | Defines the `vault` entry containing the secret token/credentials      | `source`, `destination` | `false`                                               |
+| `accessKeyId`      | Defines the access key id to access S3 Bucket/Object                   | `source`, `destination` | `false`                                               |
+| `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object            | `source`, `destination` | `false`                                               |
 
 #### S3DataSource Properties and behavior
 
@@ -73,13 +73,11 @@ Example:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "objectName": "test/object.bin",
-      "keyName": "<SECRET_KEY_IN_VAULT>"
-    }
+    "type": "AmazonS3", 
+    "bucketName": "bucketName", 
+    "region": "us-east-1", 
+    "objectName": "test/object.bin", 
+    "keyName": "<SECRET_KEY_IN_VAULT>"
   }
 }
 ```
@@ -95,14 +93,12 @@ Example:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "objectName": "test/object.bin",
-      "accessKeyId": "<ACCESS_KEY_ID>",
-      "secretAccessKey": "<SECRET_ACCESS_KEY>"
-    }
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "objectName": "test/object.bin",
+    "accessKeyId": "<ACCESS_KEY_ID>",
+    "secretAccessKey": "<SECRET_ACCESS_KEY>"
   }
 }
 ```
@@ -113,13 +109,11 @@ Example:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "objectName": "test/object.bin",
-      "keyName": "(see above)"
-    }
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "objectName": "test/object.bin",
+    "keyName": "(see above)"
   }
 }
 ```
@@ -127,13 +121,11 @@ Example:
 ```json
 {
   "dataAddress": {
-    "properties": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "objectPrefix": "test/",
-      "keyName": "(see above)"
-    }
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "objectPrefix": "test/",
+    "keyName": "(see above)"
   }
 }
 ```
@@ -144,14 +136,12 @@ Example:
 ```json
 {
     "dataDestination": {
-        "properties": {
-            "type": "AmazonS3",
-            "bucketName": "bucketName",
-            "region": "us-east-1",
-            "folderName": "destinationFolder/",
-            "objectName": "newName",
-            "keyName": "(see above)"
-        }
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "folderName": "destinationFolder/",
+      "objectName": "newName",
+      "keyName": "(see above)"
     }
 }
 ```
@@ -160,13 +150,11 @@ Example:
 ```json
 {
   "dataDestination": {
-    "properties": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "folderName": "destinationFolder/",
-      "keyName": "(see above)"
-    }
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "folderName": "destinationFolder/",
+    "keyName": "(see above)"
   }
 }
 ```

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -10,18 +10,18 @@ When as a source, it supports copying a single or multiple objects.
 
 #### Properties
 
-| Key                | Description                                                       | Applies at              | Mandatory               | Expected value                                                                                    | 
-|:-------------------|:------------------------------------------------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------------------------------|
-| `type`             | Defines the Asset type                                            | `source`, `destination` | `true`                  | AmazonS3                                                                                          |
-| `region`           | Defines the region of the bucket                                  | `source`, `destination` | `true`                  | Valid region (`us-east-1`, `eu-west-1` ...)                                                       |
-| `endpointOverride` | Defines a custom endpoint URL                                     | `source`, `destination` | `false`                 | Valid URL                                                                                         |
-| `bucketName`       | Defines the name of the S3 bucket                                 | `source`, `destination` | `true`                  | [Valid bucket name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) |
-| `objectName`       | Defines the name of the S3 object                                 | `source`, `destination` | `true` (only in source) | [Valid object name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)       |
-| `objectPrefix`     | Defines the prefix of the S3 objects to be fetched                | `source`                | `false`                 | [Valid prefix](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)         |
-| `folderName`       | Defines the folder name for S3 objects to be grouped              | `destination`           | `false`                 | [Valid folder name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)    |
-| `keyName`          | Defines the `vault` entry containing the secret token/credentials | `source`, `destination` | `false`                 | Valid `vault` entry (Varies from `vault` implementations)                                         |
-| `accessKeyId`      | Defines the access key id to access S3 Bucket/Object              | `source`, `destination` | `false`                 | Valid access key id                                                                               |
-| `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object       | `source`, `destination` | `false`                 | Valid secret access key                                                                           |
+| Key                | Description                                                            | Applies at              | Mandatory               |
+|:-------------------|:-----------------------------------------------------------------------|-------------------------|-------------------------|
+| `type`             | Defines the Asset type ( `AmazonS3` )                                  | `source`, `destination` | `true`                  |
+| `region`           | Defines the region of the bucket (`us-east-1`, `eu-west-1` ...)        | `source`, `destination` | `true`                  |
+| `endpointOverride` | Defines a custom endpoint URL                                          | `source`, `destination` | `false`                 |
+| `bucketName`       | Defines the name of the S3 bucket                                      | `source`, `destination` | `true`                  |
+| `objectName`       | Defines the name of the S3 object                                      | `source`, `destination` | `true` (only in source) |
+| `objectPrefix`     | Defines the prefix of the S3 objects to be fetched ( `objectPrefix/` ) | `source`                | `false`                 |
+| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `destination`           | `false`                 |
+| `keyName`          | Defines the `vault` entry containing the secret token/credentials      | `source`, `destination` | `false`                 |
+| `accessKeyId`      | Defines the access key id to access S3 Bucket/Object                   | `source`, `destination` | `false`                 |
+| `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object            | `source`, `destination` | `false`                 |
 
 #### S3DataSource Properties and behavior
 
@@ -65,9 +65,7 @@ possible values are:
   ```json
   {
     "sessionToken": "<SESSION_TOKEN>",
-    "expiration": "<EXPIRATION>",
-    "accessKeyId":"<ACCESS_KEY_ID>",
-    "secretAccessKey": "<SECRET_ACCESS_KEY>"
+    "expiration": "<EXPIRATION>"
   }
   ```
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -69,12 +69,43 @@ possible values are:
   }
   ```
 
+Example:
+```json
+{
+  "dataAddress": {
+    "properties": {
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "objectName": "test/object.bin",
+      "keyName": "<SECRET_KEY_IN_VAULT>"
+    }
+  }
+}
+```
+
 #### Plain text credentials
 
 This feature has been introduced to provide flexibility by not mandating the use of a `vault`. However, it is important
 to note that this functionality is not recommended for production environments.
 
-- The properties `accessKeyId` and `secretAccessKey`, can be used for basic AWS access key authentication.
+The properties `accessKeyId` and `secretAccessKey`, can be used for basic AWS access key authentication.
+
+Example:
+```json
+{
+  "dataAddress": {
+    "properties": {
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "objectName": "test/object.bin",
+      "accessKeyId": "<ACCESS_KEY_ID>",
+      "secretAccessKey": "<SECRET_ACCESS_KEY>"
+    }
+  }
+}
+```
 
 #### Source - Data Address Example
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -1,33 +1,148 @@
-## Aws S3 Data Plane module
+# Aws S3 Data Plane module
 
-### About this module
+## About this module
 
 This module contains a Data Plane extension to copy data to and from Aws S3.
 
 When as a source, it supports copying a single or multiple objects.
 
-#### AmazonS3 DataAddress Configuration
+### Configuration
+
+#### Properties
+
+| Key                | Description                                                       | Applies at              | Mandatory               | Expected value                                                                                    | 
+|:-------------------|:------------------------------------------------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------------------------------|
+| `type`             | Defines the Asset type                                            | `source`, `destination` | `true`                  | AmazonS3                                                                                          |
+| `region`           | Defines the region of the bucket                                  | `source`, `destination` | `true`                  | Valid region (`us-east-1`, `eu-west-1` ...)                                                       |
+| `endpointOverride` | Defines a custom endpoint URL                                     | `source`, `destination` | `false`                 | Valid URL                                                                                         |
+| `bucketName`       | Defines the name of the S3 bucket                                 | `source`, `destination` | `true`                  | [Valid bucket name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) |
+| `objectName`       | Defines the name of the S3 object                                 | `source`, `destination` | `true` (only in source) | [Valid object name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)       |
+| `objectPrefix`     | Defines the prefix of the S3 objects to be fetched                | `source`                | `false`                 | [Valid prefix](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)         |
+| `folderName`       | Defines the folder name for S3 objects to be grouped              | `destination`           | `false`                 | [Valid folder name](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html)    |
+| `keyName`          | Defines the `vault` entry containing the secret token/credentials | `source`, `destination` | `false`                 | Valid `vault` entry (Varies from `vault` implementations)                                         |
+| `accessKeyId`      | Defines the access key id to access S3 Bucket/Object              | `source`, `destination` | `false`                 | Valid access key id                                                                               |
+| `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object       | `source`, `destination` | `false`                 | Valid secret access key                                                                           |
+
+#### S3DataSource Properties and behavior
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
-- When `keyPrefix` is present, transfer all objects with keys that start with the specified prefix.
-- When `keyPrefix` is not present, transfer only the object with a key matching the `keyName` property.
-- Precedence: `keyPrefix` takes precedence over `keyName` when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object when necessary.
+- When `objectPrefix` is present, transfer all objects with keys that start with the specified prefix.
+- When `objectPrefix` is not present, transfer only the object with a key matching the `objectName` property.
+- Precedence: `objectPrefix` takes precedence over `objectName` when determining which objects to transfer. It allows
+  for both multiple object transfers and fetching a single object when necessary.
 
->Note: Using `keyPrefix` introduces an additional step to list all objects whose keys match the specified prefix.
- 
-#### Example Usage:
+> Note: Using `objectPrefix` introduces an additional step to list all objects whose keys match the specified prefix.
 
-Configuration with `keyPrefix`:
+#### S3DataSink Properties and behavior
 
+The destination's object naming can be tailored further through the utilization of `DataAddress` properties.
+
+- The `objectName` property allows specifying the desired name for the object in the destination. It comes into effect
+  when the `DataSource` comprises a single Part or object. If there are multiple `Part`s or the property is undefined,
+  the name of the `Part` (source object name) will be used.
+- The `folderName` property can consistently group objects in the destination, whether there is a single object or
+  multiple objects.
+
+#### Secret Resolution
+
+The `keyName` property should point to a `vault` entry that contains a JSON-serialized `SecretToken` object. The
+possible values are:
+
+- `AwsSecretToken`: Using `accessKeyId` and `secretAccessKey`, it's a form of basic AWS access key authentication. This
+  method relies on a set of long-term credentials (access key ID and secret access key) associated with an IAM user or
+  role.
+  ```json
+  {
+    "accessKeyId": "<ACCESS_KEY_ID>",
+    "secretAccessKey": "<SECRET_ACCESS_KEY>"
+  }
+  ```
+- `AwsTemporatySecretToken`: Has a `sessionToken` in addition to the `accessKeyId` and `secretAccessKey`, it is
+  typically
+  referred to as AWS temporary security credentials. This process involves assuming an IAM role to obtain short-term
+  credentials, which include an `accessKeyId`, `secretAccessKey`, and a session token.
+  ```json
+  {
+    "sessionToken": "<SESSION_TOKEN>",
+    "expiration": "<EXPIRATION>",
+    "accessKeyId":"<ACCESS_KEY_ID>",
+    "secretAccessKey": "<SECRET_ACCESS_KEY>"
+  }
+  ```
+
+#### Plain text credentials
+
+This feature has been introduced to provide flexibility by not mandating the use of a `vault`. However, it is important
+to note that this functionality is not recommended for production environments.
+
+- The properties `accessKeyId` and `secretAccessKey`, can be used for basic AWS access key authentication.
+
+#### Source - Data Address Example
+
+- Single object:
 ```json
 {
   "dataAddress": {
-    "keyName": "my-key-name",
-    "keyPrefix": "my-key-prefix/"
+    "properties": {
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "objectName": "test/object.bin",
+      "keyName": "(see above)"
+    }
+  }
+}
+```
+- Multiple objects:
+```json
+{
+  "dataAddress": {
+    "properties": {
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "objectPrefix": "test/",
+      "keyName": "(see above)"
+    }
   }
 }
 ```
 
-#### AmazonS3 Chunk size Configuration
-The maximum chunk of stream to be read, by default, is 500mb. It can be changed in the EDC config file as `edc.dataplane.aws.sink.chunk.size.mb` or in the env variables as `EDC_DATAPLANE_AWS_SINK_CHUNK_SIZE_MB`.
+#### Destination - Data Address Example
+
+- Single object:
+```json
+{
+    "dataDestination": {
+        "properties": {
+            "type": "AmazonS3",
+            "bucketName": "bucketName",
+            "region": "us-east-1",
+            "folderName": "destinationFolder/",
+            "objectName": "newName",
+            "keyName": "(see above)"
+        }
+    }
+}
+```
+
+- Multiple objects:
+```json
+{
+  "dataDestination": {
+    "properties": {
+      "type": "AmazonS3",
+      "bucketName": "bucketName",
+      "region": "us-east-1",
+      "folderName": "destinationFolder/",
+      "keyName": "(see above)"
+    }
+  }
+}
+```
+
+### AmazonS3 Chunk size Configuration
+
+The maximum chunk of stream to be read, by default, is 500mb. It can be changed in the EDC config file
+as `edc.dataplane.aws.sink.chunk.size.mb` or in the env variables as `EDC_DATAPLANE_AWS_SINK_CHUNK_SIZE_MB`.

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
@@ -66,7 +66,7 @@ public class DataPlaneS3Extension implements ServiceExtension {
         }
         var monitor = context.getMonitor();
 
-        var sourceFactory = new S3DataSourceFactory(awsClientProvider, vault, typeManager);
+        var sourceFactory = new S3DataSourceFactory(awsClientProvider, monitor, vault, typeManager);
         pipelineService.registerFactory(sourceFactory);
 
         var sinkFactory = new S3DataSinkFactory(awsClientProvider, executorService, monitor, vault, typeManager, chunkSizeInBytes);

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
@@ -36,7 +36,7 @@ class S3DataSink extends ParallelSink {
 
     private S3Client client;
     private String bucketName;
-    private String keyName;
+    private String objectName;
     private String folderName;
     private int chunkSize;
 
@@ -46,7 +46,7 @@ class S3DataSink extends ParallelSink {
     @Override
     protected StreamResult<Object> transferParts(List<DataSource.Part> parts) {
         for (var part : parts) {
-            var key = getDestinationObjectName(part.name());
+            var key = getDestinationObjectName(part.name(), parts.size());
             try (var input = part.openStream()) {
 
                 var completedParts = new ArrayList<CompletedPart>();
@@ -89,11 +89,13 @@ class S3DataSink extends ParallelSink {
         return StreamResult.success();
     }
 
-    private String getDestinationObjectName(String partName) {
+    private String getDestinationObjectName(String partName, int partsSize) {
+        var name = (partsSize == 1 && !StringUtils.isNullOrEmpty(objectName)) ? objectName : partName;
         if (!StringUtils.isNullOrEmpty(folderName)) {
-            return folderName.endsWith("/") ? folderName + partName : folderName + "/" + partName;
+            return folderName.endsWith("/") ? folderName + name : folderName + "/" + name;
+        } else {
+            return name;
         }
-        return partName;
     }
 
     @NotNull
@@ -123,8 +125,8 @@ class S3DataSink extends ParallelSink {
             return this;
         }
 
-        public Builder keyName(String keyName) {
-            sink.keyName = keyName;
+        public Builder objectName(String objectName) {
+            sink.objectName = objectName;
             return this;
         }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
@@ -32,10 +32,14 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.edc.util.string.StringUtils.isNullOrEmpty;
+
 class S3DataSink extends ParallelSink {
 
     private S3Client client;
     private String bucketName;
+    @Deprecated(since = "0.5.2")
+    private String keyName;
     private String objectName;
     private String folderName;
     private int chunkSize;
@@ -90,6 +94,12 @@ class S3DataSink extends ParallelSink {
     }
 
     private String getDestinationObjectName(String partName, int partsSize) {
+        if (isNullOrEmpty(objectName) && !isNullOrEmpty(keyName)) {
+            monitor.warning("The usage of the property \"keyName\" to define the object name is deprecated" +
+                    " since version 0.5.2. Please use the \"objectName\" property instead to name objects in " +
+                    "destination.");
+            this.objectName = keyName;
+        }
         var name = (partsSize == 1 && !StringUtils.isNullOrEmpty(objectName)) ? objectName : partName;
         if (!StringUtils.isNullOrEmpty(folderName)) {
             return folderName.endsWith("/") ? folderName + name : folderName + "/" + name;
@@ -122,6 +132,11 @@ class S3DataSink extends ParallelSink {
 
         public Builder bucketName(String bucketName) {
             sink.bucketName = bucketName;
+            return this;
+        }
+
+        public Builder keyName(String keyName) {
+            sink.keyName = keyName;
             return this;
         }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSink.java
@@ -32,8 +32,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.eclipse.edc.util.string.StringUtils.isNullOrEmpty;
-
 class S3DataSink extends ParallelSink {
 
     private S3Client client;
@@ -94,12 +92,6 @@ class S3DataSink extends ParallelSink {
     }
 
     private String getDestinationObjectName(String partName, int partsSize) {
-        if (isNullOrEmpty(objectName) && !isNullOrEmpty(keyName)) {
-            monitor.warning("The usage of the property \"keyName\" to define the object name is deprecated" +
-                    " since version 0.5.2. Please use the \"objectName\" property instead to name objects in " +
-                    "destination.");
-            this.objectName = keyName;
-        }
         var name = (partsSize == 1 && !StringUtils.isNullOrEmpty(objectName)) ? objectName : partName;
         if (!StringUtils.isNullOrEmpty(folderName)) {
             return folderName.endsWith("/") ? folderName + name : folderName + "/" + name;

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.aws.s3.validation.S3DataAddressCredentialsValidator;
-import org.eclipse.edc.aws.s3.validation.S3DataAddressValidator;
+import org.eclipse.edc.aws.s3.validation.S3DestinationDataAddressValidator;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.edc.spi.EdcException;
@@ -50,7 +50,7 @@ import static org.eclipse.edc.aws.s3.S3BucketSchema.SECRET_ACCESS_KEY;
 
 
 public class S3DataSinkFactory implements DataSinkFactory {
-    private final Validator<DataAddress> validation = new S3DataAddressValidator();
+    private final Validator<DataAddress> validation = new S3DestinationDataAddressValidator();
     private final Validator<DataAddress> credentialsValidation = new S3DataAddressCredentialsValidator();
     private final AwsClientProvider clientProvider;
     private final ExecutorService executorService;
@@ -84,6 +84,7 @@ public class S3DataSinkFactory implements DataSinkFactory {
 
         return S3DataSink.Builder.newInstance()
                 .bucketName(destination.getStringProperty(BUCKET_NAME))
+                .keyName(destination.getKeyName())
                 .objectName(destination.getStringProperty(OBJECT_NAME))
                 .folderName(destination.getStringProperty(FOLDER_NAME))
                 .requestId(request.getId())

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactory.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+import org.eclipse.edc.util.string.StringUtils;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 import org.jetbrains.annotations.NotNull;
@@ -38,10 +39,12 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.concurrent.ExecutorService;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.ACCESS_KEY_ID;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.ENDPOINT_OVERRIDE;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.FOLDER_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_NAME;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.REGION;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.SECRET_ACCESS_KEY;
 
@@ -79,15 +82,14 @@ public class S3DataSinkFactory implements DataSinkFactory {
 
         var destination = request.getDestinationDataAddress();
 
-        S3Client client = createS3Client(destination);
         return S3DataSink.Builder.newInstance()
                 .bucketName(destination.getStringProperty(BUCKET_NAME))
-                .keyName(destination.getKeyName())
+                .objectName(destination.getStringProperty(OBJECT_NAME))
                 .folderName(destination.getStringProperty(FOLDER_NAME))
                 .requestId(request.getId())
                 .executorService(executorService)
                 .monitor(monitor)
-                .client(client)
+                .client(createS3Client(destination))
                 .chunkSizeBytes(chunkSizeInBytes)
                 .build();
     }
@@ -99,22 +101,25 @@ public class S3DataSinkFactory implements DataSinkFactory {
         return validation.validate(destination).flatMap(ValidationResult::toResult);
     }
 
-    private S3Client createS3Client(DataAddress destination) {
+    private S3Client createS3Client(DataAddress address) {
+        var endpointOverride = address.getStringProperty(ENDPOINT_OVERRIDE);
+        var region = address.getStringProperty(REGION);
 
-        String endpointOverride = destination.getStringProperty(ENDPOINT_OVERRIDE);
+        var awsSecretToken = ofNullable(address.getKeyName())
+                .filter(keyName -> !StringUtils.isNullOrBlank(keyName))
+                .map(vault::resolveSecret)
+                .filter(secret -> !StringUtils.isNullOrBlank(secret))
+                .map(s -> typeManager.readValue(s, AwsTemporarySecretToken.class));
 
-        S3Client client;
-        var secret = vault.resolveSecret(destination.getKeyName());
-        if (secret != null) {
-            var secretToken = typeManager.readValue(secret, AwsTemporarySecretToken.class);
-            client = clientProvider.s3Client(S3ClientRequest.from(destination.getStringProperty(REGION), endpointOverride, secretToken));
-        } else if (credentialsValidation.validate(destination).succeeded()) {
-            var secretToken = new AwsSecretToken(destination.getStringProperty(ACCESS_KEY_ID),
-                    destination.getStringProperty(SECRET_ACCESS_KEY));
-            client = clientProvider.s3Client(S3ClientRequest.from(destination.getStringProperty(REGION), endpointOverride, secretToken));
+        if (awsSecretToken.isPresent()) {
+            return clientProvider.s3Client(S3ClientRequest.from(region, endpointOverride, awsSecretToken.get()));
+        } else if (credentialsValidation.validate(address).succeeded()) {
+            var accessKeyId = address.getStringProperty(ACCESS_KEY_ID);
+            var secretAccessKey = address.getStringProperty(SECRET_ACCESS_KEY);
+            return clientProvider.s3Client(S3ClientRequest.from(region, endpointOverride,
+                    new AwsSecretToken(accessKeyId, secretAccessKey)));
         } else {
-            client = clientProvider.s3Client(S3ClientRequest.from(destination.getStringProperty(REGION), endpointOverride));
+            return clientProvider.s3Client(S3ClientRequest.from(region, endpointOverride));
         }
-        return client;
     }
 }

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -36,8 +36,8 @@ import static org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult.succ
 class S3DataSource implements DataSource {
 
     private String bucketName;
-    private String keyName;
-    private String keyPrefix;
+    private String objectName;
+    private String objectPrefix;
     private S3Client client;
 
     private S3DataSource() {
@@ -46,7 +46,7 @@ class S3DataSource implements DataSource {
     @Override
     public StreamResult<Stream<Part>> openPartStream() {
 
-        if (keyPrefix != null) {
+        if (objectPrefix != null) {
 
             var s3Objects = this.fetchPrefixedS3Objects();
 
@@ -62,7 +62,7 @@ class S3DataSource implements DataSource {
 
         }
 
-        return success(Stream.of(new S3Part(client, keyName, bucketName)));
+        return success(Stream.of(new S3Part(client, objectName, bucketName)));
     }
 
     /**
@@ -79,7 +79,7 @@ class S3DataSource implements DataSource {
 
             var listObjectsRequest = ListObjectsV2Request.builder()
                     .bucket(bucketName)
-                    .prefix(keyPrefix)
+                    .prefix(objectPrefix)
                     .continuationToken(continuationToken)
                     .build();
 
@@ -101,30 +101,30 @@ class S3DataSource implements DataSource {
 
     private static class S3Part implements Part {
         private final S3Client client;
-        private final String keyName;
+        private final String objectName;
         private final String bucketName;
 
-        S3Part(S3Client client, String keyName, String bucketName) {
+        S3Part(S3Client client, String objectName, String bucketName) {
             this.client = client;
-            this.keyName = keyName;
+            this.objectName = objectName;
             this.bucketName = bucketName;
         }
 
         @Override
         public String name() {
-            return keyName;
+            return objectName;
         }
 
         @Override
         public long size() {
-            var request = HeadObjectRequest.builder().key(keyName).bucket(bucketName).build();
+            var request = HeadObjectRequest.builder().key(objectName).bucket(bucketName).build();
             return client.headObject(request).contentLength();
         }
 
         @Override
         public InputStream openStream() {
             try {
-                var request = GetObjectRequest.builder().key(keyName).bucket(bucketName).build();
+                var request = GetObjectRequest.builder().key(objectName).bucket(bucketName).build();
                 return client.getObject(request);
             } catch (Exception e) {
                 throw new S3DataSourceException(e.getMessage(), e);
@@ -148,13 +148,13 @@ class S3DataSource implements DataSource {
             return this;
         }
 
-        public Builder keyName(String keyName) {
-            source.keyName = keyName;
+        public Builder objectName(String objectName) {
+            source.objectName = objectName;
             return this;
         }
 
-        public Builder keyPrefix(String keyPrefix) {
-            source.keyPrefix = keyPrefix;
+        public Builder objectPrefix(String objectPrefix) {
+            source.objectPrefix = objectPrefix;
             return this;
         }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -110,15 +110,17 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
         assertThat(transferResult).succeedsWithin(5, SECONDS);
 
-        if(isSingleObject) {
-            assertThat(destinationClient.getObject(destinationBucketName, objectNameInDestination)).succeedsWithin(5, SECONDS)
+        if (isSingleObject) {
+            assertThat(destinationClient.getObject(destinationBucketName, objectNameInDestination))
+                    .succeedsWithin(5, SECONDS)
                     .extracting(ResponseBytes::response)
                     .extracting(GetObjectResponse::contentLength)
                     .extracting(Long::intValue)
                     .isEqualTo(objectContent.length());
         } else {
             for (var objectName : objectNames) {
-                assertThat(destinationClient.getObject(destinationBucketName, objectName)).succeedsWithin(5, SECONDS)
+                assertThat(destinationClient.getObject(destinationBucketName, objectName))
+                        .succeedsWithin(5, SECONDS)
                         .extracting(ResponseBytes::response)
                         .extracting(GetObjectResponse::contentLength)
                         .extracting(Long::intValue)
@@ -173,16 +175,17 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
 
         assertThat(transferResult).succeedsWithin(5, SECONDS);
 
-        if(isSingleObject) {
-            System.out.println("Fetching: " + folderNameInDestination + objectNameInDestination);
-            assertThat(destinationClient.getObject(destinationBucketName, folderNameInDestination + objectNameInDestination)).succeedsWithin(5, SECONDS)
+        if (isSingleObject) {
+            assertThat(destinationClient.getObject(destinationBucketName, folderNameInDestination +
+                    objectNameInDestination)).succeedsWithin(5, SECONDS)
                     .extracting(ResponseBytes::response)
                     .extracting(GetObjectResponse::contentLength)
                     .extracting(Long::intValue)
                     .isEqualTo(objectBody.length());
         } else {
             for (var objectName : objectNames) {
-                assertThat(destinationClient.getObject(destinationBucketName, folderNameInDestination + objectName)).succeedsWithin(5, SECONDS)
+                assertThat(destinationClient.getObject(destinationBucketName, folderNameInDestination +
+                        objectName)).succeedsWithin(5, SECONDS)
                         .extracting(ResponseBytes::response)
                         .extracting(GetObjectResponse::contentLength)
                         .extracting(Long::intValue)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -82,7 +82,7 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
         var typeManager = new TypeManager();
 
         var sinkFactory = new S3DataSinkFactory(destinationClient.getClientProvider(), Executors.newSingleThreadExecutor(), mock(Monitor.class), vault, typeManager, defaultChunkSizeInBytes);
-        var sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), vault, typeManager);
+        var sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), mock(Monitor.class), vault, typeManager);
         var sourceAddress = createDataAddress(objectNames, isSingleObject);
 
         var destinationAddress = DataAddress.Builder.newInstance()
@@ -146,7 +146,7 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
         var typeManager = new TypeManager();
 
         var sinkFactory = new S3DataSinkFactory(destinationClient.getClientProvider(), Executors.newSingleThreadExecutor(), mock(Monitor.class), vault, typeManager, defaultChunkSizeInBytes);
-        var sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), vault, typeManager);
+        var sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), mock(Monitor.class), vault, typeManager);
         var sourceAddress = createDataAddress(objectNames, isSingleObject);
 
         var destinationAddress = DataAddress.Builder.newInstance()

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -45,6 +45,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.ACCESS_KEY_ID;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.BUCKET_NAME;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.ENDPOINT_OVERRIDE;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_NAME;
+import static org.eclipse.edc.aws.s3.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.S3BucketSchema.SECRET_ACCESS_KEY;
 import static org.eclipse.edc.connector.dataplane.aws.s3.DataPlaneS3Extension.DEFAULT_CHUNK_SIZE_IN_MB;
 import static org.mockito.Mockito.mock;
@@ -125,6 +127,7 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
                 .type(S3BucketSchema.TYPE)
                 .keyName(key)
                 .property(BUCKET_NAME, sourceBucketName)
+                .property(OBJECT_NAME, key)
                 .property(S3BucketSchema.REGION, REGION)
                 .property(ACCESS_KEY_ID, sourceClient.getCredentials().accessKeyId())
                 .property(SECRET_ACCESS_KEY, sourceClient.getCredentials().secretAccessKey())
@@ -134,7 +137,7 @@ public class S3DataPlaneIntegrationTest extends AbstractS3Test {
     private DataAddress createObjectInFolderAddress(String prefix) {
         return DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
-                .property("keyPrefix", prefix)
+                .property(OBJECT_PREFIX, prefix)
                 .property(BUCKET_NAME, sourceBucketName)
                 .property(S3BucketSchema.REGION, REGION)
                 .property(ACCESS_KEY_ID, sourceClient.getCredentials().accessKeyId())

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -16,7 +16,7 @@
 package org.eclipse.edc.connector.dataplane.aws.s3;
 
 import org.eclipse.edc.aws.s3.AwsClientProvider;
-import org.eclipse.edc.aws.s3.AwsSecretToken;
+import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.spi.EdcException;
@@ -39,14 +39,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_ACCESS_KEY_ID;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_BUCKET_NAME;
-import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_KEY_NAME;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_REGION;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_SECRET_ACCESS_KEY;
-import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.VALID_SECRET_TOKEN;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.s3DataAddressWithCredentials;
 import static org.eclipse.edc.connector.dataplane.aws.s3.TestFunctions.s3DataAddressWithoutCredentials;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -146,7 +143,7 @@ class S3DataSourceFactoryTest {
     @Test
     void createSource_shouldGetTheSecretTokenFromTheVault() {
         var source = TestFunctions.s3DataAddressWithCredentials();
-        var temporaryKey = new AwsSecretToken("temporaryId", "temporarySecret");
+        var temporaryKey = new AwsTemporarySecretToken("temporaryId", "temporarySecret", null, 0);
         when(vault.resolveSecret(source.getKeyName())).thenReturn(typeManager.writeValueAsString(temporaryKey));
         var request = createRequest(source);
 
@@ -159,45 +156,8 @@ class S3DataSourceFactoryTest {
         S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
 
         assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsSecretToken.class);
+        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsTemporarySecretToken.class);
         assertThat(s3ClientRequest.endpointOverride()).isNull();
-    }
-
-    @Test
-    void createSource_should_get_secretToken_from_vault_using_its_key_alias_when_present() {
-
-        var dataAddress = DataAddress.Builder.newInstance()
-                .type(S3BucketSchema.TYPE)
-                .keyName(VALID_KEY_NAME)
-                .property(S3BucketSchema.BUCKET_NAME, VALID_BUCKET_NAME)
-                .property(S3BucketSchema.REGION, VALID_REGION)
-                .property(S3BucketSchema.SECRET_TOKEN, VALID_SECRET_TOKEN)
-                .build();
-
-        var accessKeyIdFromSecretTokenAlias = "accessKeyIdFromSecretTokenAlias";
-        var secretAccessKeyFromSecretTokenAlias = "secretAccessKeyFromSecretTokenAlias";
-        var secretToken = new AwsSecretToken(accessKeyIdFromSecretTokenAlias, secretAccessKeyFromSecretTokenAlias);
-
-        when(vault.resolveSecret(dataAddress.getStringProperty(S3BucketSchema.SECRET_TOKEN)))
-                .thenReturn(typeManager.writeValueAsString(secretToken));
-
-        var dataFlowRequest = createRequest(dataAddress);
-
-        var dataSource = factory.createSource(dataFlowRequest);
-
-        verify(vault, times(1)).resolveSecret(VALID_KEY_NAME);
-        verify(vault, times(1)).resolveSecret(VALID_SECRET_TOKEN);
-
-        assertThat(dataSource).isNotNull().isInstanceOf(S3DataSource.class);
-        verify(clientProvider).s3Client(s3ClientRequestArgumentCaptor.capture());
-        S3ClientRequest s3ClientRequest = s3ClientRequestArgumentCaptor.getValue();
-        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
-        assertThat(s3ClientRequest.endpointOverride()).isNull();
-
-        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsSecretToken.class);
-        var awsSecretToken = (AwsSecretToken) s3ClientRequest.secretToken();
-        assertThat(awsSecretToken.getAccessKeyId()).isEqualTo(accessKeyIdFromSecretTokenAlias);
-        assertThat(awsSecretToken.getSecretAccessKey()).isEqualTo(secretAccessKeyFromSecretTokenAlias);
     }
 
     private DataFlowStartMessage createRequest(DataAddress source) {

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3BucketSchema;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -52,7 +53,7 @@ class S3DataSourceFactoryTest {
     private final AwsClientProvider clientProvider = mock(AwsClientProvider.class);
     private final TypeManager typeManager = new TypeManager();
     private final Vault vault = mock(Vault.class);
-    private final S3DataSourceFactory factory = new S3DataSourceFactory(clientProvider, vault, typeManager);
+    private final S3DataSourceFactory factory = new S3DataSourceFactory(clientProvider, mock(Monitor.class), vault, typeManager);
     private final ArgumentCaptor<S3ClientRequest> s3ClientRequestArgumentCaptor = ArgumentCaptor.forClass(S3ClientRequest.class);
 
     @Test

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
@@ -35,8 +35,8 @@ import static org.mockito.Mockito.when;
 public class S3DataSourceTest {
 
     private static final String BUCKET_NAME = "bucketName";
-    private static final String KEY_NAME = "object-1";
-    private static final String KEY_PREFIX = "my-prefix/";
+    private static final String OBJECT_NAME = "object-1";
+    private static final String OBJECT_PREFIX = "my-prefix/";
     private static final String ERROR_MESSAGE = "Error message";
     private final S3Client s3ClientMock = mock(S3Client.class);
 
@@ -50,8 +50,8 @@ public class S3DataSourceTest {
 
         var s3Datasource = S3DataSource.Builder.newInstance()
                 .bucketName(BUCKET_NAME)
-                .keyName(KEY_NAME)
-                .keyPrefix(KEY_PREFIX)
+                .objectName(OBJECT_NAME)
+                .objectPrefix(OBJECT_PREFIX)
                 .client(s3ClientMock)
                 .build();
 
@@ -71,8 +71,8 @@ public class S3DataSourceTest {
 
         var s3Datasource = S3DataSource.Builder.newInstance()
                 .bucketName(BUCKET_NAME)
-                .keyName(KEY_NAME)
-                .keyPrefix(KEY_PREFIX)
+                .objectName(OBJECT_NAME)
+                .objectPrefix(OBJECT_PREFIX)
                 .client(s3ClientMock)
                 .build();
 
@@ -89,8 +89,8 @@ public class S3DataSourceTest {
 
         var s3Datasource = S3DataSource.Builder.newInstance()
                 .bucketName(BUCKET_NAME)
-                .keyName(KEY_NAME)
-                .keyPrefix(null)
+                .objectName(OBJECT_NAME)
+                .objectPrefix(null)
                 .client(s3ClientMock)
                 .build();
 
@@ -113,8 +113,8 @@ public class S3DataSourceTest {
 
         var s3Datasource = S3DataSource.Builder.newInstance()
                 .bucketName(BUCKET_NAME)
-                .keyName(KEY_NAME)
-                .keyPrefix(KEY_PREFIX)
+                .objectName(OBJECT_NAME)
+                .objectPrefix(OBJECT_PREFIX)
                 .client(s3ClientMock)
                 .build();
 

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/TestFunctions.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/TestFunctions.java
@@ -37,7 +37,7 @@ public class TestFunctions {
                 .property(S3BucketSchema.REGION, VALID_REGION)
                 .property(S3BucketSchema.ACCESS_KEY_ID, VALID_ACCESS_KEY_ID)
                 .property(S3BucketSchema.SECRET_ACCESS_KEY, VALID_SECRET_ACCESS_KEY)
-                .property(S3BucketSchema.SECRET_TOKEN, VALID_SECRET_TOKEN)
+                .property(S3BucketSchema.OBJECT_NAME, VALID_SECRET_TOKEN)
                 .build();
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/TestFunctions.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/TestFunctions.java
@@ -25,9 +25,9 @@ public class TestFunctions {
     public static final String VALID_REGION = "validRegion";
     public static final String VALID_BUCKET_NAME = "validBucketName";
     public static final String VALID_KEY_NAME = "validKeyName";
+    public static final String VALID_OBJECT_NAME = "validObjectName";
     public static final String VALID_ACCESS_KEY_ID = "validAccessKeyId";
     public static final String VALID_SECRET_ACCESS_KEY = "validSecretAccessKey";
-    public static final String VALID_SECRET_TOKEN = "validSecretToken";
 
     public static DataAddress s3DataAddressWithCredentials() {
         return DataAddress.Builder.newInstance()
@@ -35,9 +35,9 @@ public class TestFunctions {
                 .keyName(VALID_KEY_NAME)
                 .property(S3BucketSchema.BUCKET_NAME, VALID_BUCKET_NAME)
                 .property(S3BucketSchema.REGION, VALID_REGION)
+                .property(S3BucketSchema.OBJECT_NAME, VALID_OBJECT_NAME)
                 .property(S3BucketSchema.ACCESS_KEY_ID, VALID_ACCESS_KEY_ID)
                 .property(S3BucketSchema.SECRET_ACCESS_KEY, VALID_SECRET_ACCESS_KEY)
-                .property(S3BucketSchema.OBJECT_NAME, VALID_SECRET_TOKEN)
                 .build();
     }
 
@@ -47,6 +47,7 @@ public class TestFunctions {
                 .keyName(VALID_KEY_NAME)
                 .property(S3BucketSchema.BUCKET_NAME, VALID_BUCKET_NAME)
                 .property(S3BucketSchema.REGION, VALID_REGION)
+                .property(S3BucketSchema.OBJECT_NAME, VALID_OBJECT_NAME)
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

- Introduces the `objectName` property to store the S3 object name
- Refactors `keyName` to exclusively handle secret aliases
- Renames `keyPrefix` to `objectPrefix`
- Destination object(s) naming decision based on `Part` list size.
- Updates documentation
- Updates tests

## Why it does that

To align with the existing behavior of `TransferProcessManagerImpl`, which defaults to using `keyName` for fetching secret values, rather than introducing a new property configuration specifically for holding the secret alias, a more effective approach would be to introduce an `objectName` property to store the S3 object name. This modification aims to enhance consistency and also alignment between the `AWS` and `Azure` platforms.

## Linked Issue(s)

Closes #211
