### PR TITLE
feat: Modifies the AWS vault implementation to update existing secrets

### DIFF
--- a/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVault.java
+++ b/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVault.java
@@ -87,6 +87,9 @@ public class AwsSecretsManagerVault implements Vault {
                 monitor.severe(serviceException.getMessage(), serviceException);
                 return Result.failure(serviceException.getMessage());
             }
+        } catch (RuntimeException serviceException) {
+            monitor.severe(serviceException.getMessage(), serviceException);
+            return Result.failure(serviceException.getMessage());
         }
     }
 

--- a/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVault.java
+++ b/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVault.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 
 /**
  * Vault adapter for AWS Secrets Manager.
@@ -62,7 +63,7 @@ public class AwsSecretsManagerVault implements Vault {
     }
 
     /**
-     * Creates a new secret. Does not overwrite secrets.
+     * Creates/Updates a secret.
      *
      * @param key   the secret key
      * @param value the serialized secret value
@@ -71,15 +72,21 @@ public class AwsSecretsManagerVault implements Vault {
     @Override
     public Result<Void> storeSecret(String key, String value) {
         var sanitizedKey = sanitizer.sanitizeKey(key);
-        var request = CreateSecretRequest.builder().name(sanitizedKey)
-                .secretString(value).build();
         try {
-            monitor.debug(String.format("Storing secret '%s' to AWS Secrets manager", sanitizedKey));
-            smClient.createSecret(request);
+            var updateSecretRequest = UpdateSecretRequest.builder().secretId(sanitizedKey).secretString(value).build();
+            smClient.updateSecret(updateSecretRequest);
+            monitor.debug(String.format("Secret '%s' updated in AWS Secrets Manager", sanitizedKey));
             return Result.success();
-        } catch (RuntimeException serviceException) {
-            monitor.severe(serviceException.getMessage(), serviceException);
-            return Result.failure(serviceException.getMessage());
+        } catch (ResourceNotFoundException e) {
+            try {
+                var createSecretRequest = CreateSecretRequest.builder().name(sanitizedKey).secretString(value).build();
+                smClient.createSecret(createSecretRequest);
+                monitor.debug(String.format("Secret '%s' stored in AWS Secrets Manager", sanitizedKey));
+                return Result.success();
+            } catch (RuntimeException serviceException) {
+                monitor.severe(serviceException.getMessage(), serviceException);
+                return Result.failure(serviceException.getMessage());
+            }
         }
     }
 
@@ -103,6 +110,5 @@ public class AwsSecretsManagerVault implements Vault {
             return Result.failure(serviceException.getMessage());
         }
     }
-
 
 }


### PR DESCRIPTION

## What this PR changes/adds

This PR updates the AWS Vault implementation to match the behavior of HashiCorp Vault. Previously, the `store` method in the AWS Vault implementation only created new secrets. With this update, the method now supports both creating and updating secrets, aligning it with the behavior of HashiCorp Vault.

## Why it does that
This update is required because the recent addition of the [Secrets Manager API](https://github.com/eclipse-edc/Connector/pull/4138) introduces the capability to update secrets. As a result, the AWS Vault implementation must be updated to handle secret updates in addition to secret creation.

## Linked Issue(s)

Closes #373 

