### PR TITLE
feat(ci): create tag and merge commit manually

### DIFF
--- a/.github/workflows/release-tech-aws.yml
+++ b/.github/workflows/release-tech-aws.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Create tag on current branch (main)
         run: |
           git tag v${{ env.EDC_VERSION }}
+          git push origin tag v${{ env.EDC_VERSION }}
 
       # create merge commit main -> releases encoding the version in the commit message
       - name: Merge main -> releases

--- a/.github/workflows/release-tech-aws.yml
+++ b/.github/workflows/release-tech-aws.yml
@@ -23,26 +23,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "eclipse-edc-bot"
+          git config user.email "edc-bot@eclipse.org"
+
       # create tag on the current branch using GitHub's own API
       - name: Create tag on current branch (main)
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/v${{ env.EDC_VERSION }}',
-              sha: context.sha
-            })
+        run: |
+          git tag v${{ env.EDC_VERSION }}
 
       # create merge commit main -> releases encoding the version in the commit message
       - name: Merge main -> releases
-        uses: everlytic/branch-merge@1.1.5
-        with:
-          github_token: ${{ github.token }}
-          source_ref: ${{ github.ref }}
-          target_branch: 'releases'
-          commit_message_template: 'Merge commit for release of version v${{ env.EDC_VERSION }}'
+        run: |
+          git fetch origin releases --unshallow
+          git checkout --track origin/releases 
+          git merge main -m "Merge commit for release of version v${{ env.EDC_VERSION }}"
+          git push origin releases
 
     outputs:
       edc-version: ${{ env.EDC_VERSION }}

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -17,7 +17,7 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approve
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-api/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
-maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.0, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15745
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, CC-BY-2.5, approved, #15220
@@ -237,7 +237,7 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.8, MIT, approved, #10344
 maven/mavencentral/org.testcontainers/junit-jupiter/1.20.0, MIT, approved, clearlydefined
 maven/mavencentral/org.testcontainers/testcontainers/1.19.8, MIT, approved, #15203
-maven/mavencentral/org.testcontainers/testcontainers/1.20.0, MIT, restricted, clearlydefined
+maven/mavencentral/org.testcontainers/testcontainers/1.20.0, None, restricted, #15747
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/software.amazon.awssdk/annotations/2.25.66, Apache-2.0, approved, #13691
 maven/mavencentral/software.amazon.awssdk/apache-client/2.25.66, Apache-2.0, approved, #13687


### PR DESCRIPTION
## What this PR changes/adds

Switches to creating the tags and merge commit using plain bash (as opposed to: GH actions)

## Why it does that

There were weird, unreproducible and undebuggable `"merge conflict"` errors in the past. Also, bash scripts are easier to debug and replicate locally.

## Further notes

- successful test in my fork: https://github.com/paullatzelsperger/Technology-Aws/actions/runs/10056788484

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
