### PR TITLE
Use generator service to register AmazonS3 destination type

### DIFF
--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3ExtensionTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3ExtensionTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.connector.dataplane.aws.s3;
 
+import org.eclipse.edc.aws.s3.spi.S3BucketSchema;
+import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -21,6 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.function.Function;
+
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -29,10 +34,12 @@ import static org.mockito.Mockito.verify;
 class DataPlaneS3ExtensionTest {
 
     private final PipelineService pipelineService = mock();
+    private final PublicEndpointGeneratorService generatorService = mock();
 
     @BeforeEach
     void setup(ServiceExtensionContext context) {
         context.registerService(PipelineService.class, pipelineService);
+        context.registerService(PublicEndpointGeneratorService.class, generatorService);
     }
 
     @Test
@@ -41,5 +48,12 @@ class DataPlaneS3ExtensionTest {
 
         verify(pipelineService).registerFactory(isA(S3DataSinkFactory.class));
         verify(pipelineService).registerFactory(isA(S3DataSourceFactory.class));
+    }
+
+    @Test
+    void shouldInvokePublicEndpointGeneratorService(DataPlaneS3Extension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(generatorService).addGeneratorFunction(eq(S3BucketSchema.TYPE), isA(Function.class));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR aims to fix the addition of AmazonS3 destination type by the generator service in the initialiaztion of the extension. 

## Why it does that

With the removal of sourcetypes properties from the dataplane selector logic, now the destination type must be registered during the boot and so this change allows that for the AmazonS3 type.

## Further notes

Tests were added for existing class to promote quality and consistency.

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Technology-Aws/issues/401