### PR TITLE
feat: Modifies the AWS vault implementation to update existing secrets (Backport)

### DIFF
--- a/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultTest.java
+++ b/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultTest.java
@@ -72,7 +72,7 @@ class AwsSecretsManagerVaultTest {
 
     @Test
     void storeSecret_shouldUpdateSecretIfExist() {
-        String value = "value";
+        var value = "value";
 
         vault.storeSecret(KEY, value);
 

--- a/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultTest.java
+++ b/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultTest.java
@@ -80,8 +80,11 @@ class AwsSecretsManagerVaultTest {
 
         vault.storeSecret(KEY, value);
 
-        verify(secretClient).updateSecret(UpdateSecretRequest.builder().secretId(SANITIZED_KEY)
-                .secretString(value).build());
+        verify(secretClient).updateSecret(argThat((UpdateSecretRequest request) -> {
+            var secretId = request.secretId();
+            var secretValue = request.secretString();
+            return SANITIZED_KEY.equals(secretId) && value.equals(secretValue);
+        }));
 
         verifyNoMoreInteractions(secretClient);
 
@@ -96,8 +99,11 @@ class AwsSecretsManagerVaultTest {
         vault.storeSecret(KEY, value);
 
         verify(secretClient).updateSecret(any(UpdateSecretRequest.class));
-        verify(secretClient).createSecret(CreateSecretRequest.builder().name(SANITIZED_KEY)
-                .secretString(value).build());
+        verify(secretClient).createSecret(argThat((CreateSecretRequest request) -> {
+            var secretId = request.name();
+            var secretValue = request.secretString();
+            return SANITIZED_KEY.equals(secretId) && value.equals(secretValue);
+        }));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

This PR updates the AWS Vault implementation to match the behavior of HashiCorp Vault. Previously, the store method in the AWS Vault implementation only created new secrets. With this update, the method now supports both creating and updating secrets, aligning it with the behavior of HashiCorp Vault.

## Why it does that

This update is required because the recent addition of the [Secrets Manage API](https://github.com/eclipse-edc/Connector/pull/4138 ) introduces the capability to update secrets. As a result, the AWS Vault implementation must be updated to handle secret updates in addition to secret creation.

## Further Notes

This is a backport from [PR](https://github.com/eclipse-edc/Technology-Aws/pull/379)
