### PR TITLE
fix(dataplane): deserialize secret depending on content

### DIFF
--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/DataPlaneS3Extension.java
@@ -68,10 +68,10 @@ public class DataPlaneS3Extension implements ServiceExtension {
         }
         var monitor = context.getMonitor();
 
-        var sourceFactory = new S3DataSourceFactory(awsClientProvider, monitor, vault, typeManager, validator);
+        var sourceFactory = new S3DataSourceFactory(awsClientProvider, monitor, vault, typeManager.getMapper(), validator);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new S3DataSinkFactory(awsClientProvider, executorService, monitor, vault, typeManager, chunkSizeInBytes, validator);
+        var sinkFactory = new S3DataSinkFactory(awsClientProvider, executorService, monitor, vault, typeManager.getMapper(), chunkSizeInBytes, validator);
         pipelineService.registerFactory(sinkFactory);
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -10,17 +10,20 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       ZF Friedrichshafen AG - Initial implementation
+ *       Cofinity-X - fix secret deserialization
  *
  */
 
 package org.eclipse.edc.connector.dataplane.aws.s3;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.eclipse.edc.aws.s3.AwsClientProvider;
 import org.eclipse.edc.aws.s3.AwsSecretToken;
 import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.aws.s3.spi.S3BucketSchema;
 import org.eclipse.edc.aws.s3.validation.S3DataAddressCredentialsValidator;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.SecretToken;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
 import org.eclipse.edc.spi.EdcException;
@@ -35,6 +38,8 @@ import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
 
 import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.ACCESS_KEY_ID;
@@ -105,7 +110,7 @@ public class S3DataSourceFactory implements DataSourceFactory {
                 .filter(keyName -> !StringUtils.isNullOrBlank(keyName))
                 .map(vault::resolveSecret)
                 .filter(secret -> !StringUtils.isNullOrBlank(secret))
-                .map(s -> typeManager.readValue(s, AwsTemporarySecretToken.class));
+                .map(this::deserializeSecretToken);
 
         if (awsSecretToken.isPresent()) {
             return S3ClientRequest.from(region, endpointOverride, awsSecretToken.get());
@@ -118,5 +123,14 @@ public class S3DataSourceFactory implements DataSourceFactory {
             return S3ClientRequest.from(region, endpointOverride);
         }
     }
-
+    
+    private SecretToken deserializeSecretToken(String secret) {
+        var typeReference = new TypeReference<HashMap<String, Object>>() {};
+        var map = typeManager.readValue(secret, typeReference);
+        if (map.containsKey("sessionToken")) {
+            return typeManager.readValue(secret, AwsTemporarySecretToken.class);
+        } else {
+            return typeManager.readValue(secret, AwsSecretToken.class);
+        }
+    }
 }

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -86,8 +86,8 @@ public class S3DataPlaneIntegrationTest {
 
         var typeManager = new JacksonTypeManager();
         var chunkSizeInBytes = 1024 * 1024 * 20;
-        sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), mock(), mock(), typeManager, validator);
-        sinkFactory = new S3DataSinkFactory(destinationClient.getClientProvider(), Executors.newSingleThreadExecutor(), mock(), mock(), typeManager, chunkSizeInBytes, validator);
+        sourceFactory = new S3DataSourceFactory(sourceClient.getClientProvider(), mock(), mock(), typeManager.getMapper(), validator);
+        sinkFactory = new S3DataSinkFactory(destinationClient.getClientProvider(), Executors.newSingleThreadExecutor(), mock(), mock(), typeManager.getMapper(), chunkSizeInBytes, validator);
 
         sourceClient.createBucket(sourceBucketName);
         destinationClient.createBucket(destinationBucketName);

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
@@ -50,8 +50,8 @@ class S3DataSinkFactoryTest {
     private final TypeManager typeManager = new JacksonTypeManager();
     private final DataAddressValidatorRegistry validator = mock();
 
-    private final S3DataSinkFactory factory = new S3DataSinkFactory(clientProvider, mock(), mock(), vault, typeManager,
-            1024, validator);
+    private final S3DataSinkFactory factory = new S3DataSinkFactory(clientProvider, mock(), mock(),
+            vault, typeManager.getMapper(), 1024, validator);
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSinkFactoryTest.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       ZF Friedrichshafen AG
+ *       Cofinity-X - additional test for secret deserialization
  *
  */
 
@@ -92,6 +93,25 @@ class S3DataSinkFactoryTest {
 
         assertThat(result).isFailed();
         verify(validator).validateDestination(destination);
+    }
+    
+    @Test
+    void createSink_shouldGetTheSecretTokenFromTheVault() {
+        var destination = TestFunctions.s3DataAddressWithCredentials();
+        var secretToken = new AwsSecretToken("accessKeyId", "secretAccessKey");
+        when(vault.resolveSecret(destination.getKeyName())).thenReturn(typeManager.writeValueAsString(secretToken));
+        when(validator.validateDestination(any())).thenReturn(ValidationResult.success());
+        var request = createRequest(destination);
+        
+        var sink = factory.createSink(request);
+        
+        assertThat(sink).isNotNull().isInstanceOf(S3DataSink.class);
+        var captor = ArgumentCaptor.forClass(S3ClientRequest.class);
+        verify(clientProvider).s3Client(captor.capture());
+        var s3ClientRequest = captor.getValue();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsSecretToken.class);
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
 
     @Test

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -10,12 +10,14 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *       ZF Friedrichshafen AG - Initial implementation
+ *       Cofinity-X - additional test for secret deserialization
  *
  */
 
 package org.eclipse.edc.connector.dataplane.aws.s3;
 
 import org.eclipse.edc.aws.s3.AwsClientProvider;
+import org.eclipse.edc.aws.s3.AwsSecretToken;
 import org.eclipse.edc.aws.s3.AwsTemporarySecretToken;
 import org.eclipse.edc.aws.s3.S3ClientRequest;
 import org.eclipse.edc.aws.s3.spi.S3BucketSchema;
@@ -120,9 +122,28 @@ class S3DataSourceFactoryTest {
         assertThat(s3ClientRequest.secretToken()).isNull();
         assertThat(s3ClientRequest.endpointOverride()).isNull();
     }
-
+    
     @Test
     void createSource_shouldGetTheSecretTokenFromTheVault() {
+        when(validator.validateSource(any())).thenReturn(ValidationResult.success());
+        var source = TestFunctions.s3DataAddressWithCredentials();
+        var secretToken = new AwsSecretToken("accessKeyId", "secretAccessKey");
+        when(vault.resolveSecret(source.getKeyName())).thenReturn(typeManager.writeValueAsString(secretToken));
+        var request = createRequest(source);
+        
+        var s3Source = factory.createSource(request);
+        
+        assertThat(s3Source).isNotNull().isInstanceOf(S3DataSource.class);
+        var captor = ArgumentCaptor.forClass(S3ClientRequest.class);
+        verify(clientProvider).s3Client(captor.capture());
+        var s3ClientRequest = captor.getValue();
+        assertThat(s3ClientRequest.region()).isEqualTo(TestFunctions.VALID_REGION);
+        assertThat(s3ClientRequest.secretToken()).isInstanceOf(AwsSecretToken.class);
+        assertThat(s3ClientRequest.endpointOverride()).isNull();
+    }
+
+    @Test
+    void createSource_shouldGetTheTemporarySecretTokenFromTheVault() {
         when(validator.validateSource(any())).thenReturn(ValidationResult.success());
         var source = TestFunctions.s3DataAddressWithCredentials();
         var temporaryKey = new AwsTemporarySecretToken("temporaryId", "temporarySecret", null, 0);

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactoryTest.java
@@ -51,7 +51,8 @@ class S3DataSourceFactoryTest {
     private final Vault vault = mock();
     private final DataAddressValidatorRegistry validator = mock();
 
-    private final S3DataSourceFactory factory = new S3DataSourceFactory(clientProvider, mock(), vault, typeManager, validator);
+    private final S3DataSourceFactory factory = new S3DataSourceFactory(clientProvider, mock(),
+            vault, typeManager.getMapper(), validator);
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {


### PR DESCRIPTION
## What this PR changes/adds

Deserializes the secret obtained from the vault to either an `AwsSecretToken` or an `AwsTemporarySecretToken` depending on whether it contains a `sessionToken` field or not.

## Why it does that

To allow both the usage of static and temporary credentials with the S3 data plane. Previously, the secret was always deserialized directly to an `AwsTemporarySecretToken`, which caused the transfer to fail if static credentials were used.

## Further notes

The code for deserializing the secret has been duplicated for `S3DataSourceFactory` and `S3DataSinkFactory` for now, as also the code for creating the S3 client request is duplicated. Refactoring to remove these duplications should be done in another PR.

## Linked Issue(s)

Closes #457 
