### PR TITLE
feat: allow endpoint overrides in AwsSecretsManagerVault

### DIFF
--- a/extensions/common/vault/vault-aws/build.gradle.kts
+++ b/extensions/common/vault/vault-aws/build.gradle.kts
@@ -20,4 +20,6 @@ dependencies {
     api(libs.edc.spi.core)
     implementation(libs.aws.secretsmanager)
     implementation(libs.edc.lib.util)
+
+    testImplementation(libs.edc.junit)
 }

--- a/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtension.java
+++ b/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtension.java
@@ -38,12 +38,12 @@ public class AwsSecretsManagerVaultExtension implements ServiceExtension {
 
     @Setting(key = "edc.vault.aws.region",
             description = "The AWS Secrets Manager client will point to the specified region")
-    String vaultRegion;
+    private String vaultRegion;
 
     @Setting(key = "edc.vault.aws.endpoint.override",
             description = "If valued, the AWS Secrets Manager client will point to the specified endpoint",
             required = false)
-    String vaultAwsEndpointOverride;
+    private String vaultAwsEndpointOverride;
 
     @Override
     public String name() {
@@ -56,16 +56,12 @@ public class AwsSecretsManagerVaultExtension implements ServiceExtension {
                 .map(URI::create)
                 .orElse(null);
 
-        var smClient = buildSmClient(vaultRegion, vaultEndpointOverride);
-
-        return new AwsSecretsManagerVault(smClient, context.getMonitor(),
-                new AwsSecretsManagerVaultDefaultSanitationStrategy(context.getMonitor()));
-    }
-
-    private SecretsManagerClient buildSmClient(String vaultRegion, URI vaultEndpointOverride) {
         var builder = SecretsManagerClient.builder()
                 .region(Region.of(vaultRegion))
                 .endpointOverride(vaultEndpointOverride);
-        return builder.build();
+        var smClient = builder.build();
+
+        return new AwsSecretsManagerVault(smClient, context.getMonitor(),
+                new AwsSecretsManagerVaultDefaultSanitationStrategy(context.getMonitor()));
     }
 }

--- a/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtension.java
+++ b/extensions/common/vault/vault-aws/src/main/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtension.java
@@ -36,11 +36,14 @@ import java.util.Optional;
 public class AwsSecretsManagerVaultExtension implements ServiceExtension {
     public static final String NAME = "AWS Secrets Manager Vault";
 
-    @Setting
-    private static final String VAULT_AWS_REGION = "edc.vault.aws.region";
+    @Setting(key = "edc.vault.aws.region",
+            description = "The AWS Secrets Manager client will point to the specified region")
+    String vaultRegion;
 
-    @Setting
-    private static final String AWS_ENDPOINT_OVERRIDE = "edc.aws.endpoint.override";
+    @Setting(key = "edc.vault.aws.endpoint.override",
+            description = "If valued, the AWS Secrets Manager client will point to the specified endpoint",
+            required = false)
+    String vaultAwsEndpointOverride;
 
     @Override
     public String name() {
@@ -49,9 +52,7 @@ public class AwsSecretsManagerVaultExtension implements ServiceExtension {
 
     @Provider
     public Vault createVault(ServiceExtensionContext context) {
-        var vaultRegion = context.getConfig().getString(VAULT_AWS_REGION);
-        var vaultEndpointOverride = Optional.of(AWS_ENDPOINT_OVERRIDE)
-                .map(key -> context.getSetting(key, null))
+        var vaultEndpointOverride = Optional.ofNullable(vaultAwsEndpointOverride)
                 .map(URI::create)
                 .orElse(null);
 

--- a/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
@@ -42,9 +42,8 @@ class AwsSecretsManagerVaultExtensionTest {
     @Test
     void configOptionRegionNotProvided_shouldThrowException() {
         var extension = new AwsSecretsManagerVaultExtension();
-        ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
 
-        Assertions.assertThrows(NullPointerException.class, () -> extension.createVault(invalidContext));
+        Assertions.assertThrows(NullPointerException.class, () -> extension.createVault(context));
     }
 
     @Test

--- a/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
@@ -16,46 +16,59 @@ package org.eclipse.edc.vault.aws;
 
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.configuration.Config;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class AwsSecretsManagerVaultExtensionTest {
+    private static ServiceExtensionContext context;
 
-    private final Monitor monitor = mock(Monitor.class);
-    private final AwsSecretsManagerVaultExtension extension = new AwsSecretsManagerVaultExtension();
+    @BeforeAll
+    public static void beforeAll() {
+        context = mock(ServiceExtensionContext.class);
+        when(context.getMonitor()).thenReturn(mock(Monitor.class));
+    }
+
 
     @Test
     void configOptionRegionNotProvided_shouldThrowException() {
+        var extension = new AwsSecretsManagerVaultExtension();
         ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
-        when(invalidContext.getMonitor()).thenReturn(monitor);
 
         Assertions.assertThrows(NullPointerException.class, () -> extension.createVault(invalidContext));
     }
 
     @Test
     void configOptionRegionProvided_shouldNotThrowException() {
-        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
-        Config cfg = mock();
-        when(cfg.getString("edc.vault.aws.region")).thenReturn("eu-west-1");
-        when(validContext.getConfig()).thenReturn(cfg);
-        when(validContext.getMonitor()).thenReturn(monitor);
+        var extension = new AwsSecretsManagerVaultExtension();
+        extension.vaultRegion = "eu-west-1";
 
-        extension.createVault(validContext);
+        var vault = extension.createVault(context);
+
+        assertThat(vault).extracting("smClient", type(SecretsManagerClient.class)).satisfies(client -> {
+            assertThat(client.serviceClientConfiguration().region()).isEqualTo(Region.of("eu-west-1"));
+        });
     }
 
     @Test
     void configOptionEndpointOverrideProvided_shouldNotThrowException() {
-        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
-        Config cfg = mock();
-        when(cfg.getString("edc.vault.aws.region")).thenReturn("eu-west-1");
-        when(cfg.getString("edc.aws.endpoint.override")).thenReturn("http://localhost:4566");
-        when(validContext.getConfig()).thenReturn(cfg);
-        when(validContext.getMonitor()).thenReturn(monitor);
+        var extension = new AwsSecretsManagerVaultExtension();
+        extension.vaultRegion = "eu-west-1";
+        extension.vaultAwsEndpointOverride = "http://localhost:4566";
 
-        extension.createVault(validContext);
+        var vault = extension.createVault(context);
+
+        assertThat(vault).extracting("smClient", type(SecretsManagerClient.class)).satisfies(client -> {
+            assertThat(client.serviceClientConfiguration().endpointOverride()).contains(URI.create("http://localhost:4566"));
+        });
     }
 }

--- a/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-aws/src/test/java/org/eclipse/edc/vault/aws/AwsSecretsManagerVaultExtensionTest.java
@@ -47,4 +47,15 @@ class AwsSecretsManagerVaultExtensionTest {
         extension.createVault(validContext);
     }
 
+    @Test
+    void configOptionEndpointOverrideProvided_shouldNotThrowException() {
+        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+        Config cfg = mock();
+        when(cfg.getString("edc.vault.aws.region")).thenReturn("eu-west-1");
+        when(cfg.getString("edc.aws.endpoint.override")).thenReturn("http://localhost:4566");
+        when(validContext.getConfig()).thenReturn(cfg);
+        when(validContext.getMonitor()).thenReturn(monitor);
+
+        extension.createVault(validContext);
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

`AwsSecretsManagerVaultExtension` do not allow to override AWS endpoint. However, `S3CoreExtension` allows it. So, I implements endpoint overrides in `AwsSecretsManagerVault` using `edc.aws.endpoint.override` the same param of `S3CoreExtension`.

## Why it does that

For AWS-compatible services like localstack.

Closes #486 
