### PR TITLE
fix: iamAsyncClient without endpointOverride

### DIFF
--- a/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
+++ b/extensions/common/aws/aws-s3-core/src/main/java/org/eclipse/edc/aws/s3/AwsClientProviderImpl.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - Initial implementation
  *       ZF Friedrichshafen AG - Initial implementation
+ *       Cofinity-X - fix iamAsyncClient without endpointOverride
  *
  */
 
@@ -42,6 +43,8 @@ import java.util.concurrent.Executors;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 
 public class AwsClientProviderImpl implements AwsClientProvider {
+    
+    private static final String NO_ENDPOINT_OVERRIDE = "default";
 
     private final AwsCredentialsProvider credentialsProvider;
     private final AwsClientProviderConfiguration configuration;
@@ -70,7 +73,7 @@ public class AwsClientProviderImpl implements AwsClientProvider {
 
     @Override
     public IamAsyncClient iamAsyncClient(S3ClientRequest clientRequest) {
-        var key = clientRequest.endpointOverride();
+        var key = clientRequest.endpointOverride() != null ? clientRequest.endpointOverride() : NO_ENDPOINT_OVERRIDE;
         return iamAsyncClients.computeIfAbsent(key, s -> createIamAsyncClient(clientRequest.endpointOverride()));
     }
 

--- a/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/AwsClientProviderImplTest.java
+++ b/extensions/common/aws/aws-s3-core/src/test/java/org/eclipse/edc/aws/s3/AwsClientProviderImplTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.aws.s3;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AwsClientProviderImplTest {
+
+    private AwsClientProvider clientProvider;
+    
+    @BeforeEach
+    void setUp() {
+        var config = AwsClientProviderConfiguration.Builder.newInstance()
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+        clientProvider = new AwsClientProviderImpl(config);
+    }
+    
+    @Test
+    void iamAsyncClient_noEndpointOverride_shouldReturnClient() {
+        var clientRequest = S3ClientRequest.from("region", null);
+        
+        var client = clientProvider.iamAsyncClient(clientRequest);
+        
+        assertThat(client).isNotNull();
+        assertThat(client.serviceClientConfiguration().endpointOverride()).isEmpty();
+    }
+    
+    @Test
+    void iamAsyncClient_requestMultipleTimesNoEndpointOverride_shouldReturnSameClient() {
+        var clientRequest = S3ClientRequest.from("region", null);
+        
+        var client1 = clientProvider.iamAsyncClient(clientRequest);
+        var client2 = clientProvider.iamAsyncClient(clientRequest);
+        
+        assertThat(client1).isSameAs(client2);
+    }
+    
+    @Test
+    void iamAsyncClient_withEndpointOverride_shouldReturnClient() {
+        var endpointOverride = "https://endpointOverride";
+        var clientRequest = S3ClientRequest.from("region", endpointOverride);
+    
+        var client = clientProvider.iamAsyncClient(clientRequest);
+    
+        assertThat(client).isNotNull();
+        assertThat(client.serviceClientConfiguration().endpointOverride()).contains(URI.create(endpointOverride));
+    }
+    
+    @Test
+    void iamAsyncClient_requestMultipleTimesWithEndpointOverride_shouldReturnSameClient() {
+        var clientRequest = S3ClientRequest.from("region", "https://endpointOverride");
+        
+        var client1 = clientProvider.iamAsyncClient(clientRequest);
+        var client2 = clientProvider.iamAsyncClient(clientRequest);
+        
+        assertThat(client1).isSameAs(client2);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Defines a default key that will be used by the `AwsClientProviderImpl` to cache a created `IamAsyncClient` if no `endpointOverride` property is supplied in the client request. The default key is only used for IAM clients, as all other client types are region-bound and for them, a combination of `region` and `endpointOverride` properties is used as the key, thus no NullPointerException is raised there on a missing `endpointOverride`.

## Why it does that

Previously only the `endpointOverride` property was used as the key for storing `IamAsyncClients`, causing a NullPointerException if no `endpointOverride` was supplied.

## Further notes
I noticed that we do not yet have any tests for the `AwsClientProviderImpl`. I added only the relevant tests for the fix for now, but we should create a follow-up issue to add additional tests for this class.

## Linked Issue(s)

Closes #490 
