### PR TITLE
docs: update examples for secret tokens in data plane README

### DIFF
--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -54,6 +54,7 @@ possible values are:
   role.
   ```json
   {
+    "edctype": "dataspaceconnector:secrettoken",
     "accessKeyId": "<ACCESS_KEY_ID>",
     "secretAccessKey": "<SECRET_ACCESS_KEY>"
   }
@@ -61,9 +62,14 @@ possible values are:
 - `AwsTemporatySecretToken`: Has a `sessionToken` in addition to the `accessKeyId` and `secretAccessKey`, it is
   typically
   referred to as AWS temporary security credentials. This process involves assuming an IAM role to obtain short-term
-  credentials, which include an `accessKeyId`, `secretAccessKey`, and a session token.
+  credentials, which include an `accessKeyId`, `secretAccessKey`, and a session token. In addition to these fields,
+  the token expiration time, which is received together with the credentials upon assuming a role or otherwise 
+  requesting temporary credentials, has to be specified as a **unix timestamp**.
   ```json
   {
+    "edctype": "dataspaceconnector:secrettoken",
+    "accessKeyId": "<ACCESS_KEY_ID>",
+    "secretAccessKey": "<SECRET_ACCESS_KEY>",  
     "sessionToken": "<SESSION_TOKEN>",
     "expiration": "<EXPIRATION>"
   }


### PR DESCRIPTION
## What this PR changes/adds

Updates the examples and documentation regarding secret tokens in the `data-plane-aws-s3` `README`. Namely, adds the following:
- `edctype` field in JSON examples
- `accessKeyId` and `secretAccessKey` fields in JSON example for `AwsTemporarySecretToken`
- a note regarding the expiration time for temporary tokens

## Why it does that

Previously, the JSON examples were incomplete, possibly causing confusion/errors when strictly following the `README`.

## Linked Issue(s)

Closes #491 

