### PR TITLE
feat: Create a S3 bucket during provision only if one does not previously exist

### DIFF
--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ProvisionPipeline.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ProvisionPipeline.java
@@ -88,13 +88,14 @@ public class S3ProvisionPipeline {
         var stsClient = clientProvider.stsAsyncClient(rq);
         var bucketName = resourceDefinition.getBucketName();
         var headBucketRequest = HeadBucketRequest.builder().bucket(bucketName).build();
-        var createBucketRequest = CreateBucketRequest.builder().bucket(bucketName).createBucketConfiguration(CreateBucketConfiguration.builder().build()).build();
 
         return s3AsyncClient.headBucket(headBucketRequest).thenCompose(response -> {
             monitor.debug("S3ProvisionPipeline: bucket " + bucketName + " already exists, skipping creation");
             return CompletableFuture.completedFuture(null);
         }).exceptionally(throwable -> {
             monitor.debug("S3ProvisionPipeline: creating bucket " + bucketName + " as it does not exist");
+            var createBucketRequest = CreateBucketRequest.builder().bucket(bucketName)
+                    .createBucketConfiguration(CreateBucketConfiguration.builder().build()).build();
             return s3AsyncClient.createBucket(createBucketRequest);
         })
                 .thenCompose(r -> getUser(iamClient))

--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ProvisionPipeline.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ProvisionPipeline.java
@@ -89,14 +89,13 @@ public class S3ProvisionPipeline {
         var bucketName = resourceDefinition.getBucketName();
         var headBucketRequest = HeadBucketRequest.builder().bucket(bucketName).build();
         var createBucketRequest = CreateBucketRequest.builder().bucket(bucketName).createBucketConfiguration(CreateBucketConfiguration.builder().build()).build();
-        monitor.debug("S3ProvisionPipeline: checking if bucket " + bucketName + " exists");
 
         return s3AsyncClient.headBucket(headBucketRequest).thenCompose(response -> {
             monitor.debug("S3ProvisionPipeline: bucket " + bucketName + " already exists, skipping creation");
             return CompletableFuture.completedFuture(null);
         }).exceptionally(throwable -> {
-            monitor.debug("S3ProvisionPipeline: create bucket " + bucketName + " as it does not exist");
-            return s3AsyncClient.createBucket(createBucketRequest).join();
+            monitor.debug("S3ProvisionPipeline: creating bucket " + bucketName + " as it does not exist");
+            return s3AsyncClient.createBucket(createBucketRequest);
         })
                 .thenCompose(r -> getUser(iamClient))
                 .thenCompose(response -> createRole(iamClient, resourceDefinition, response))

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3BucketProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3BucketProvisionerTest.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.iam.model.User;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,7 +73,7 @@ class S3BucketProvisionerTest {
     }
 
     @Test
-    void verify_basic_provision() {
+    void verify_basic_provision_with_bucket_creation() {
         var userResponse = GetUserResponse.builder().user(User.builder().arn("testarn").build()).build();
         var createRoleResponse = CreateRoleResponse.builder().role(Role.builder().roleName("roleName").arn("testarn").build()).build();
         var putRolePolicyResponse = PutRolePolicyResponse.builder().build();
@@ -85,6 +87,7 @@ class S3BucketProvisionerTest {
         var assumeRoleResponse = AssumeRoleResponse.builder().credentials(credentials).build();
         when(stsClient.assumeRole(isA(AssumeRoleRequest.class))).thenReturn(completedFuture(assumeRoleResponse));
 
+        when(s3Client.headBucket(isA(HeadBucketRequest.class))).thenReturn(failedFuture(new RuntimeException("any")));
         var createBucketResponse = CreateBucketResponse.builder().build();
         when(s3Client.createBucket(isA(CreateBucketRequest.class))).thenReturn(completedFuture(createBucketResponse));
 
@@ -100,10 +103,12 @@ class S3BucketProvisionerTest {
             assertThat(secretToken.sessionToken()).isEqualTo("sessionToken");
         });
         verify(iamClient).putRolePolicy(isA(PutRolePolicyRequest.class));
+        verify(s3Client).createBucket(isA(CreateBucketRequest.class));
     }
 
     @Test
     void should_return_failed_future_on_error() {
+        when(s3Client.headBucket(isA(HeadBucketRequest.class))).thenReturn(failedFuture(new RuntimeException("any")));
         when(s3Client.createBucket(isA(CreateBucketRequest.class))).thenReturn(failedFuture(new RuntimeException("any")));
         S3BucketResourceDefinition definition = S3BucketResourceDefinition.Builder.newInstance().id("test").regionId(Region.US_EAST_1.id()).bucketName("test").transferProcessId("test").build();
 
@@ -112,6 +117,40 @@ class S3BucketProvisionerTest {
         var response = provisioner.provision(definition, policy);
 
         assertThat(response).failsWithin(1, SECONDS);
+        verify(s3Client).createBucket(isA(CreateBucketRequest.class));
+    }
+
+    @Test
+    void verify_basic_provision_with_existing_bucket() {
+        var userResponse = GetUserResponse.builder().user(User.builder().arn("testarn").build()).build();
+        var createRoleResponse = CreateRoleResponse.builder().role(Role.builder().roleName("roleName").arn("testarn").build()).build();
+        var putRolePolicyResponse = PutRolePolicyResponse.builder().build();
+        when(iamClient.getUser()).thenReturn(completedFuture(userResponse));
+        when(iamClient.createRole(isA(CreateRoleRequest.class))).thenReturn(completedFuture(createRoleResponse));
+        when(iamClient.putRolePolicy(isA(PutRolePolicyRequest.class))).thenReturn(completedFuture(putRolePolicyResponse));
+
+        var credentials = Credentials.builder()
+                .accessKeyId("accessKeyId").secretAccessKey("secretAccessKey").sessionToken("sessionToken")
+                .expiration(Instant.now()).build();
+        var assumeRoleResponse = AssumeRoleResponse.builder().credentials(credentials).build();
+        when(stsClient.assumeRole(isA(AssumeRoleRequest.class))).thenReturn(completedFuture(assumeRoleResponse));
+
+        when(s3Client.headBucket(isA(HeadBucketRequest.class))).thenReturn(completedFuture(null));
+
+        S3BucketResourceDefinition definition = S3BucketResourceDefinition.Builder.newInstance().id("test").regionId(Region.US_EAST_1.id()).bucketName("test").transferProcessId("test").build();
+        var policy = Policy.Builder.newInstance().build();
+
+        var response = provisioner.provision(definition, policy).join().getContent();
+
+        assertThat(response.getResource()).isInstanceOfSatisfying(S3BucketProvisionedResource.class, resource -> assertThat(resource.getRole()).isEqualTo("roleName"));
+        assertThat(response.getSecretToken()).isInstanceOfSatisfying(AwsTemporarySecretToken.class, secretToken -> {
+            assertThat(secretToken.accessKeyId()).isEqualTo("accessKeyId");
+            assertThat(secretToken.secretAccessKey()).isEqualTo("secretAccessKey");
+            assertThat(secretToken.sessionToken()).isEqualTo("sessionToken");
+        });
+        verify(iamClient).putRolePolicy(isA(PutRolePolicyRequest.class));
+        verify(s3Client).headBucket(isA(HeadBucketRequest.class));
+        verify(s3Client, times(0)).createBucket(isA(CreateBucketRequest.class));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Ensures validation of S3 bucket existence during provision to only try to create it if it does not already exist.

## Why it does that

Right now, if the bucket exists, then an Exception is thrown during provision. This impedes of (for example) copying data to the target bucket since provision cannot happen.

## Linked Issue(s)

Closes #552 
