### PR TITLE
fix: NullPointerException in S3ConsumerResourceDefinitionGenerator

### DIFF
--- a/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGenerator.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/main/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGenerator.java
@@ -11,6 +11,7 @@
  *       Microsoft Corporation - initial API and implementation
  *       ZF Friedrichshafen AG - improvements (refactoring of generate method)
  *       SAP SE - refactoring
+ *       Cofinity-X - fix exception in canGenerate for PULL transfers
  *
  */
 
@@ -68,6 +69,7 @@ public class S3ConsumerResourceDefinitionGenerator implements ConsumerResourceDe
 
     @Override
     public boolean canGenerate(TransferProcess dataRequest, Policy policy) {
-        return S3BucketSchema.TYPE.equals(dataRequest.getDestinationType());
+        return dataRequest.getDataDestination() != null &&
+                S3BucketSchema.TYPE.equals(dataRequest.getDestinationType());
     }
 }

--- a/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
+++ b/extensions/control-plane/provision/provision-aws-s3/src/test/java/org/eclipse/edc/connector/provision/aws/s3/S3ConsumerResourceDefinitionGeneratorTest.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       ZF Friedrichshafen AG - Initial API and Implementation
  *       SAP SE - refactoring
+ *       Cofinity-X - fix exception in canGenerate for PULL transfers
  *
  */
 
@@ -179,4 +180,15 @@ public class S3ConsumerResourceDefinitionGeneratorTest {
         assertThat(definition).isFalse();
     }
 
+    @Test
+    void canGenerate_dataDestinationNull_shouldReturnFalse() {
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .assetId("asset-id")
+                .contractId("contract-id")
+                .build();
+        var policy = Policy.Builder.newInstance().build();
+        
+        var definition = generator.canGenerate(transferProcess, policy);
+        assertThat(definition).isFalse();
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a null check for the `dataDestination` in `canGenerate()` of `S3ConsumerResourceDefinitionGenerator`.

## Why it does that

to avoid NullPointerException on PULL transfers


## Who will sponsor this feature?

me


## Linked Issue(s)

Closes #578 

