### PR TITLE
feat: Add FolderName attribute to S3DataSource

### DIFF
--- a/extensions/common/validator/validator-data-address-s3/src/main/java/org/eclipse/edc/aws/s3/validator/S3SourceDataAddressValidator.java
+++ b/extensions/common/validator/validator-data-address-s3/src/main/java/org/eclipse/edc/aws/s3/validator/S3SourceDataAddressValidator.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.BUCKET_NAME;
+import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.FOLDER_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.REGION;
@@ -44,11 +45,11 @@ public class S3SourceDataAddressValidator implements Validator<DataAddress> {
             }
         });
 
-        if (Stream.of(OBJECT_NAME, OBJECT_PREFIX)
+        if (Stream.of(OBJECT_NAME, OBJECT_PREFIX, FOLDER_NAME)
                 .map(dataAddress::getStringProperty)
                 .allMatch(it -> (it == null || it.isBlank()))) {
-            violations.add(violation("Either the '%s' or '%s' attribute must be provided."
-                    .formatted(OBJECT_NAME, OBJECT_PREFIX), OBJECT_NAME, null));
+            violations.add(violation("Either the '%s' or '%s' or '%s' attribute must be provided."
+                    .formatted(OBJECT_NAME, OBJECT_PREFIX, FOLDER_NAME), OBJECT_NAME, null));
         }
 
         if (violations.isEmpty()) {

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -27,15 +27,20 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
-- When only `folderName` is present, transfer all objects with keys that start with the specified `folderName`, knowing
-  it will be removed from the transferred object name unless a defined `objectName` is present in DataSink.
-- When only `objectPrefix` is present, transfer all objects with keys that start with the specified `objectPrefix`.
-- When `folderName` and `objectPrefix` are present, transfer all the objects with keys that start with the specified
-  `folderName` + `objectPrefix`. The first will be removed from the transferred object name unless a defined 
-  `objectName` is present in DataSink.
+- There are three different ways to select objects by specifying a `folderName` and/or a `objectPrefix`.
+  Objects in an S3 bucket are persisted under the same root directory (the bucket), and a structured organization is
+  achievable by using object key prefixes. There are cases where maintaining the key prefix in the data destination
+  is desirable but other cases where it's not.
+  When using `folderName`, one can aggregate objects contained within a folder like structure. The `folderName` part will
+  be removed in the destination.
+  Using `objectPrefix`, one can aggregate objects whose key is prefixed by the specified string. The property can still
+  be used for folder like aggregation but the prefix part will not be removed in the destination.
+  When used in combination, both properties will be used for object selection through the concatenation of `folderName`
+  with `objectPrefix` (`folderName` + `objectPrefix`). Similarly, the `folderName` part will be removed from the object name
+  in the destination.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
-- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to 
+- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to
   transfer. It allows for both multiple object transfers and fetching a single object when necessary.
 
 > Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -36,7 +36,7 @@ The behavior of object transfers can be customized using `DataAddress` propertie
   when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
   when necessary.
 
-> Note: Using `folderName` or `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter" (folderName + objectPrefix).
+> Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".
 
 ### S3DataSink Properties and behavior
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -27,14 +27,16 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
-- When `folderName` is present, transfer all objects with keys that start with the specified name. The folderName will
-  be removed from the transferred object name.
-- When `objectPrefix` is present, transfer all objects with keys that start with the specified prefix.
+- When only `folderName` is present, transfer all objects with keys that start with the specified `folderName`, knowing
+  it will be removed from the transferred object name unless a defined `objectName` is present in DataSink.
+- When only `objectPrefix` is present, transfer all objects with keys that start with the specified `objectPrefix`.
+- When `folderName` and `objectPrefix` are present, transfer all the objects with keys that start with the specified
+  `folderName` + `objectPrefix`. The first will be removed from the transferred object name unless a defined 
+  `objectName` is present in DataSink.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
-- Precedence: `folderName` takes precedence over `objectPrefix` and `objectPrefix` takes precedence over `objectName`
-  when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
-  when necessary.
+- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to 
+  transfer. It allows for both multiple object transfers and fetching a single object when necessary.
 
 > Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -18,7 +18,7 @@ When as a source, it supports copying a single or multiple objects.
 | `bucketName`       | Defines the name of the S3 bucket                                      | `source`, `destination` | `true`                                                |
 | `objectName`       | Defines the name of the S3 object                                      | `source`, `destination` | `true` (in `source` if `objectPrefix` is not present) |
 | `objectPrefix`     | Defines the prefix of the S3 objects to be fetched ( `objectPrefix/` ) | `source`                | `true` (if `objectName` is not present)               |
-| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `destination`           | `false`                                               |
+| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `source`, `destination` | `false`                                               |
 | `keyName`          | Defines the `vault` entry containing the secret token/credentials      | `source`, `destination` | `false`                                               |
 | `accessKeyId`      | Defines the access key id to access S3 Bucket/Object                   | `source`, `destination` | `false`                                               |
 | `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object            | `source`, `destination` | `false`                                               |
@@ -27,12 +27,16 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
+- When `folderName` is present, transfer all objects with keys that start with the specified name. The folderName will
+  be removed from the transferred object name.
 - When `objectPrefix` is present, transfer all objects with keys that start with the specified prefix.
-- When `objectPrefix` is not present, transfer only the object with a key matching the `objectName` property.
-- Precedence: `objectPrefix` takes precedence over `objectName` when determining which objects to transfer. It allows
-  for both multiple object transfers and fetching a single object when necessary.
+- When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
+  property.
+- Precedence: `folderName` takes precedence over `objectPrefix` and `objectPrefix` takes precedence over `objectName`
+  when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
+  when necessary.
 
-> Note: Using `objectPrefix` introduces an additional step to list all objects whose keys match the specified prefix.
+> Note: Using `folderName` or `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter" (folderName + objectPrefix).
 
 ### S3DataSink Properties and behavior
 
@@ -63,7 +67,7 @@ possible values are:
   typically
   referred to as AWS temporary security credentials. This process involves assuming an IAM role to obtain short-term
   credentials, which include an `accessKeyId`, `secretAccessKey`, and a session token. In addition to these fields,
-  the token expiration time, which is received together with the credentials upon assuming a role or otherwise 
+  the token expiration time, which is received together with the credentials upon assuming a role or otherwise
   requesting temporary credentials, has to be specified as a **unix timestamp**.
   ```json
   {
@@ -79,10 +83,10 @@ Example:
 ```json
 {
   "dataAddress": {
-    "type": "AmazonS3", 
-    "bucketName": "bucketName", 
-    "region": "us-east-1", 
-    "objectName": "test/object.bin", 
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "objectName": "test/object.bin",
     "keyName": "<SECRET_KEY_IN_VAULT>"
   }
 }
@@ -143,14 +147,14 @@ Example:
 - Single object:
 ```json
 {
-    "dataDestination": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "folderName": "destinationFolder/",
-      "objectName": "newName",
-      "keyName": "(see above)"
-    }
+  "dataDestination": {
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "folderName": "destinationFolder/",
+    "objectName": "newName",
+    "keyName": "(see above)"
+  }
 }
 ```
 
@@ -180,21 +184,21 @@ In order to be able to use an S3 bucket as the source of a transfer, the user/ro
 Example:
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "my-statement",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<bucket-name>",
-                "arn:aws:s3:::<bucket-name>/*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "my-statement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<bucket-name>",
+        "arn:aws:s3:::<bucket-name>/*"
+      ]
+    }
+  ]
 }
 ```
 
@@ -206,19 +210,19 @@ In order to be able to use an S3 bucket as the destination of a transfer, the us
 Example:
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "my-statement",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<bucket-name>/*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "my-statement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<bucket-name>/*"
+      ]
+    }
+  ]
 }
 ```
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -56,8 +56,8 @@ class S3DataSource implements DataSource {
         }
 
         var refinedFolderName = getRefinedFolderName(folderName);
-        var filter = getFilter(refinedFolderName, objectPrefix);
-        var s3Objects = this.fetchFilteredByFolderNameAndOrPrefixS3Objects(filter);
+        var prefix = getPrefix(refinedFolderName, objectPrefix);
+        var s3Objects = this.fetchPrefixedS3Objects(prefix);
 
         if (s3Objects.isEmpty()) {
             return failure(new StreamFailure(
@@ -77,7 +77,7 @@ class S3DataSource implements DataSource {
      *
      * @return A list of S3 objects.
      */
-    private List<S3Object> fetchFilteredByFolderNameAndOrPrefixS3Objects(String filter) {
+    private List<S3Object> fetchPrefixedS3Objects(String prefix) {
 
         String continuationToken = null;
         List<S3Object> s3Objects = new ArrayList<>();
@@ -85,7 +85,7 @@ class S3DataSource implements DataSource {
         do {
             var listObjectsRequest = ListObjectsV2Request.builder()
                     .bucket(bucketName)
-                    .prefix(filter)
+                    .prefix(prefix)
                     .continuationToken(continuationToken)
                     .build();
 
@@ -96,8 +96,8 @@ class S3DataSource implements DataSource {
 
         return s3Objects;
     }
-    
-    private String getFilter(String folderName, String objectPrefix) {
+
+    private String getPrefix(String folderName, String objectPrefix) {
         return (folderName + (objectPrefix != null ? objectPrefix : ""));
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -68,7 +68,7 @@ class S3DataSource implements DataSource {
             objectFolderName += "/";
         }
 
-        if (!(objectFolderName == null && objectPrefix == null)) {
+        if (!(isNullOrEmpty(objectFolderName) && isNullOrEmpty(objectPrefix))) {
 
             var filter = getFilter(objectFolderName, objectPrefix);
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.connector.dataplane.aws.s3.exceptions.S3DataSourceExcepti
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
-import org.eclipse.edc.spi.monitor.Monitor;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -39,15 +38,10 @@ import static org.eclipse.edc.util.string.StringUtils.isNullOrEmpty;
 class S3DataSource implements DataSource {
 
     private String bucketName;
-    @Deprecated(since = "0.5.2")
-    private String keyName;
     private String objectName;
-    @Deprecated(since = "0.5.2")
-    private String keyPrefix;
     private String folderName;
     private String objectPrefix;
     private S3Client client;
-    private Monitor monitor;
 
     private final Predicate<S3Object> isFile = object -> !object.key().endsWith("/");
 
@@ -56,13 +50,6 @@ class S3DataSource implements DataSource {
 
     @Override
     public StreamResult<Stream<Part>> openPartStream() {
-
-        if (isNullOrEmpty(objectPrefix) && !isNullOrEmpty(keyPrefix)) {
-            monitor.warning("The usage of the property \"keyPrefix\" to define the object prefix is deprecated" +
-                    " since version 0.5.2. Please use the \"objectPrefix\" property instead to store this value for" +
-                    " new assets. Additionally, update existing assets to use the \"objectPrefix\" property.");
-            this.objectPrefix = keyPrefix;
-        }
 
         if (!(isNullOrEmpty(folderName) && isNullOrEmpty(objectPrefix))) {
 
@@ -82,13 +69,6 @@ class S3DataSource implements DataSource {
 
             return success(s3PartStream);
 
-        }
-
-        if (isNullOrEmpty(objectName) && !isNullOrEmpty(keyName)) {
-            monitor.warning("The usage of the property \"keyName\" to define the object name is deprecated" +
-                    " since version 0.5.2. Please use the \"objectName\" property instead to store this value for" +
-                    " new assets. Additionally, update existing assets to use the \"objectName\" property.");
-            this.objectName = keyName;
         }
 
         return success(Stream.of(new S3Part(client, objectName, bucketName, "")));
@@ -190,11 +170,6 @@ class S3DataSource implements DataSource {
             return this;
         }
 
-        public Builder keyName(String keyName) {
-            source.keyName = keyName;
-            return this;
-        }
-
         public Builder objectName(String objectName) {
             source.objectName = objectName;
             return this;
@@ -205,11 +180,6 @@ class S3DataSource implements DataSource {
             return this;
         }
 
-        public Builder keyPrefix(String keyPrefix) {
-            source.keyPrefix = keyPrefix;
-            return this;
-        }
-
         public Builder objectPrefix(String objectPrefix) {
             source.objectPrefix = objectPrefix;
             return this;
@@ -217,11 +187,6 @@ class S3DataSource implements DataSource {
 
         public Builder client(S3Client client) {
             source.client = client;
-            return this;
-        }
-
-        public Builder monitor(Monitor monitor) {
-            source.monitor = monitor;
             return this;
         }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -125,8 +125,12 @@ class S3DataSource implements DataSource {
     }
 
     private String getRefinedFolderName(String folderName) {
-        if (isNullOrEmpty(folderName)) return "";
-        folderName += !folderName.endsWith("/") ? "/" : "";
+        if (isNullOrEmpty(folderName)) {
+            return "";
+        }
+        if (!folderName.endsWith("/")) {
+            return folderName + "/";
+        }
         return folderName;
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -66,9 +66,8 @@ class S3DataSource implements DataSource {
 
         var s3PartStream = s3Objects.stream()
                 .map(S3Object::key)
-                .map(key -> !isNullOrEmpty(refinedFolderName) ? key.substring(refinedFolderName.length()) : key)
+                .map(key -> key.substring(refinedFolderName.length()))
                 .map(key -> (Part) new S3Part(client, key, bucketName, refinedFolderName));
-
         return success(s3PartStream);
     }
 
@@ -98,7 +97,7 @@ class S3DataSource implements DataSource {
     }
 
     private String getPrefix(String folderName, String objectPrefix) {
-        return (folderName + (objectPrefix != null ? objectPrefix : ""));
+        return folderName + (objectPrefix != null ? objectPrefix : "");
     }
 
     private String getRefinedFolderName(String folderName) {

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -71,9 +71,7 @@ class S3DataSource implements DataSource {
         if (!(isNullOrEmpty(objectFolderName) && isNullOrEmpty(objectPrefix))) {
 
             var filter = getFilter(objectFolderName, objectPrefix);
-
             var s3Objects = this.fetchFilteredByFolderNameAndOrPrefixS3Objects(filter);
-
             objectFolderName = !(isNullOrEmpty(objectFolderName) || objectFolderName.equals("/")) ? objectFolderName : "";
 
             if (s3Objects.isEmpty()) {
@@ -111,7 +109,6 @@ class S3DataSource implements DataSource {
         List<S3Object> s3Objects = new ArrayList<>();
 
         do {
-
             var listObjectsRequest = ListObjectsV2Request.builder()
                     .bucket(bucketName)
                     .prefix(filter)
@@ -119,26 +116,18 @@ class S3DataSource implements DataSource {
                     .build();
 
             var response = client.listObjectsV2(listObjectsRequest);
-
             s3Objects.addAll(response.contents().stream().filter(isFile).toList());
-
             continuationToken = response.nextContinuationToken();
-
         } while (continuationToken != null);
 
         return s3Objects;
     }
 
     private String getFilter(String objectFolderName, String objectPrefix) {
-
-        StringBuilder filter = new StringBuilder();
-
         objectFolderName = objectFolderName != null ? objectFolderName : "";
         objectPrefix = objectPrefix != null ? objectPrefix : "";
 
-        filter.append(objectFolderName).append(objectPrefix);
-
-        return filter.toString();
+        return (objectFolderName + objectPrefix);
     }
 
     @Override

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -116,7 +116,7 @@ class S3DataSource implements DataSource {
 
     }
 
-    private static class S3Part implements Part {
+    protected static class S3Part implements Part {
         private final S3Client client;
         private final String objectName;
         private final String bucketName;
@@ -136,7 +136,7 @@ class S3DataSource implements DataSource {
 
         @Override
         public long size() {
-            var request = HeadObjectRequest.builder().key(objectName).bucket(bucketName).build();
+            var request = HeadObjectRequest.builder().key(folderName + objectName).bucket(bucketName).build();
             return client.headObject(request).contentLength();
         }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -84,12 +84,10 @@ public class S3DataSourceFactory implements DataSourceFactory {
 
         return S3DataSource.Builder.newInstance()
                 .bucketName(source.getStringProperty(BUCKET_NAME))
-                .keyName(source.getKeyName())
                 .objectName(source.getStringProperty(OBJECT_NAME))
                 .folderName(source.getStringProperty(FOLDER_NAME))
                 .objectPrefix(source.getStringProperty(OBJECT_PREFIX))
                 .client(this.clientProvider.s3Client(s3ClientRequest))
-                .monitor(monitor)
                 .build();
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -44,6 +44,7 @@ import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.ACCESS_KEY_ID;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.BUCKET_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.ENDPOINT_OVERRIDE;
+import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.FOLDER_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.REGION;
@@ -85,6 +86,7 @@ public class S3DataSourceFactory implements DataSourceFactory {
                 .bucketName(source.getStringProperty(BUCKET_NAME))
                 .keyName(source.getKeyName())
                 .objectName(source.getStringProperty(OBJECT_NAME))
+                .folderName(source.getStringProperty(FOLDER_NAME))
                 .objectPrefix(source.getStringProperty(OBJECT_PREFIX))
                 .client(this.clientProvider.s3Client(s3ClientRequest))
                 .monitor(monitor)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -154,7 +154,7 @@ public class S3DataPlaneIntegrationTest {
 
     @ParameterizedTest
     @ArgumentsSource(MultiObjectsNamesToTransfer.class)
-    void shouldCopy_UsingDestinationfolderName_InMultiFileTransfer(String folderName, String prefix, List<String> objectNames) {
+    void shouldCopy_UsingDestinationFolderName_InMultiFileTransfer(String folderName, String prefix, List<String> objectNames) {
 
         var folderNameInDestination = "folder-name-in-destination/";
         var objectNameInDestination = "object-name-in-destination";

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -61,6 +61,7 @@ public class S3DataPlaneIntegrationTest {
     private static final String OBJECT_FOLDER_NAME = "object-folder-name/";
     private static final String OBJECT_PREFIX = "object-prefix/";
     private static final String KEY_NAME = "key-name";
+    private static final String OBJECT_NAME = "text-document.txt";
 
     @Container
     private final MinioContainer sourceMinio = new MinioContainer();
@@ -258,8 +259,6 @@ public class S3DataPlaneIntegrationTest {
 
     private static class SingleObjectNamesToTransfer implements ArgumentsProvider {
 
-        private static final String OBJECT_NAME = "text-document.txt";
-
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
@@ -271,8 +270,6 @@ public class S3DataPlaneIntegrationTest {
     }
 
     private static class MultiObjectsNamesToTransfer implements ArgumentsProvider {
-
-        private static final String OBJECT_NAME = "text-document.txt";
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -117,7 +117,7 @@ public class S3DataPlaneIntegrationTest {
         objectKey.append(name);
         sourceClient.putStringOnBucket(sourceBucketName, objectKey.toString(), objectContent);
 
-        var sourceAddress = singleObjectCreateDataAddress(folderName, prefix, name);
+        var sourceAddress = createSingleObjectDataAddress(folderName, prefix, name);
 
         var destinationAddress = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
@@ -175,7 +175,7 @@ public class S3DataPlaneIntegrationTest {
             sourceClient.putStringOnBucket(sourceBucketName, objectKey.toString(), objectContent);
         }
 
-        var sourceAddress = multiObjectsCreateDataAddress(folderName, prefix);
+        var sourceAddress = createMultiObjectsDataAddress(folderName, prefix);
 
         var destinationAddress = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
@@ -220,7 +220,7 @@ public class S3DataPlaneIntegrationTest {
         }
     }
 
-    private DataAddress singleObjectCreateDataAddress(String folderName, String prefix, String name) {
+    private DataAddress createSingleObjectDataAddress(String folderName, String prefix, String name) {
         var dataAddressBuilder = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
                 .keyName(KEY_NAME)
@@ -238,7 +238,7 @@ public class S3DataPlaneIntegrationTest {
         return dataAddressBuilder.property(S3BucketSchema.OBJECT_NAME, name).build();
     }
 
-    private DataAddress multiObjectsCreateDataAddress(String folderName, String prefix) {
+    private DataAddress createMultiObjectsDataAddress(String folderName, String prefix) {
         var dataAddressBuilder = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
                 .keyName(KEY_NAME)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
@@ -55,7 +55,6 @@ public class S3DataSourceTest {
 
     @Test
     void should_select_prefixed_objects_case_key_prefix_is_present() {
-
         var mockResponse = ListObjectsV2Response.builder().contents(
                 S3Object.builder().key("my-prefix/object-1").build(),
                 S3Object.builder().key("my-prefix/object-2").build()
@@ -79,7 +78,6 @@ public class S3DataSourceTest {
 
     @Test
     void should_fail_case_no_object_is_found() {
-
         var mockResponse = ListObjectsV2Response.builder().build();
 
         var s3Datasource = S3DataSource.Builder.newInstance()
@@ -99,7 +97,6 @@ public class S3DataSourceTest {
 
     @Test
     void should_select_single_object_case_key_prefix_is_not_present() {
-
         var s3Datasource = S3DataSource.Builder.newInstance()
                 .bucketName(BUCKET_NAME)
                 .objectName(OBJECT_NAME)
@@ -116,7 +113,6 @@ public class S3DataSourceTest {
 
     @Test
     void should_throw_datasource_exception_case_object_fetching_fails() {
-
         var mockResponse = ListObjectsV2Response.builder().contents(
                 S3Object.builder().key("my-prefix/object-1").build(),
                 S3Object.builder().key("my-prefix/object-2").build()
@@ -142,22 +138,9 @@ public class S3DataSourceTest {
 
     @ParameterizedTest
     @ArgumentsSource(S3DataSourceInput.class)
-    void shouldSelectFilteredByFolderNameAndOrPrefixS3Objects(String folderName, String prefix, String name, String expectedValue) {
-
-        var key = new StringBuilder();
-        if (folderName != null) {
-            key.append(folderName);
-            if (!folderName.endsWith("/")) {
-                key.append("/");
-            }
-        }
-        if (prefix != null) {
-            key.append(prefix);
-        }
-        key.append(name);
-
+    void shouldSelectFilteredByFolderNameAndOrPrefixS3Objects(String folderName, String prefix, String name, String key, String expectedValue) {
         var mockResponse = ListObjectsV2Response.builder().contents(
-                S3Object.builder().key(key.toString()).build()
+                S3Object.builder().key(key).build()
         ).build();
 
         var s3Datasource = S3DataSource.Builder.newInstance()
@@ -215,10 +198,10 @@ public class S3DataSourceTest {
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 
             return Stream.of(
-                    Arguments.of(OBJECT_FOLDER_NAME, OBJECT_PREFIX, OBJECT_NAME, OBJECT_PREFIX + OBJECT_NAME),
-                    Arguments.of(OBJECT_FOLDER_NAME.substring(0, OBJECT_FOLDER_NAME.length() - 1), null, OBJECT_NAME, OBJECT_NAME),
-                    Arguments.of(null, OBJECT_PREFIX, OBJECT_NAME, OBJECT_PREFIX + OBJECT_NAME),
-                    Arguments.of(null, null, OBJECT_NAME, OBJECT_NAME));
+                    Arguments.of(OBJECT_FOLDER_NAME, OBJECT_PREFIX, OBJECT_NAME, OBJECT_FOLDER_NAME + OBJECT_PREFIX + OBJECT_NAME, OBJECT_PREFIX + OBJECT_NAME),
+                    Arguments.of(OBJECT_FOLDER_NAME.substring(0, OBJECT_FOLDER_NAME.length() - 1), null, OBJECT_NAME, OBJECT_FOLDER_NAME + OBJECT_NAME, OBJECT_NAME),
+                    Arguments.of(null, OBJECT_PREFIX, OBJECT_NAME, OBJECT_PREFIX + OBJECT_NAME, OBJECT_PREFIX + OBJECT_NAME),
+                    Arguments.of(null, null, OBJECT_NAME, OBJECT_NAME, OBJECT_NAME));
         }
     }
 }

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -32,8 +34,10 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -171,6 +175,22 @@ public class S3DataSourceTest {
         var list = result.getContent().toList();
         assertThat(list.get(0).name()).isEqualTo(expectedValue);
     }
+
+    @Test
+    void shouldFail_when() {
+        var s3Part = new S3DataSource.S3Part(s3Client, OBJECT_PREFIX + OBJECT_NAME, BUCKET_NAME, OBJECT_FOLDER_NAME);
+
+        var expectedRequest = HeadObjectRequest.builder()
+                .key(OBJECT_FOLDER_NAME + OBJECT_PREFIX + OBJECT_NAME)
+                .bucket(BUCKET_NAME)
+                .build();
+
+        when(s3Client.headObject(eq(expectedRequest)))
+                .thenReturn(HeadObjectResponse.builder().contentLength(2L).build());
+
+        assertDoesNotThrow(s3Part::size);
+    }
+
 
     @Nested
     class Close {


### PR DESCRIPTION
## What this PR changes/adds

Add the FolderName attribute to the S3DataSource, which allows the user to specify the exact name in the destination that will be retrieved using FolderName and Prefix as filters.

## Why it does that

With the implementation of this feature, users can now select assets as before, but by combining both attributes, take control of the outcome file(s) name(s).

For a quick example, let's consider an S3 bucket on the provider side with two files (file1 and file2) and three different requests. The non-relevant attributes to this feature showcase will be omitted.

Path in Source (S3): 
folder/prefix/file1
folder/prefix/file2

Request1 :    OBJECT_PREFIX = "folder/prefix/"
Output1: [folder/prefix/file1, folder/prefix/file2]

Request2:    FOLDER_NAME = "folder/" && OBJECT_PREFIX = "prefix/"
Output2: [prefix/file1, prefix/file2]

Request3:    FOLDER_NAME = "folder/prefix/"
Output3: [file1, file2]

Currently, only a Request1 type is available. This implies that the file name will always include the full path found in the source.

## Further notes

Documentation and Validator were changed to accommodate folderName.

To keep the code DRY, the integration tests were implemented within some preexisting ones.


## Who will sponsor this feature?

toBeAdded

## Linked Issue(s)

Closes #580  