### PR TITLE
feat: Allow transfer of entire s3 bucket

### DIFF
--- a/extensions/common/validator/validator-data-address-s3/src/main/java/org/eclipse/edc/aws/s3/validator/S3SourceDataAddressValidator.java
+++ b/extensions/common/validator/validator-data-address-s3/src/main/java/org/eclipse/edc/aws/s3/validator/S3SourceDataAddressValidator.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.BUCKET_NAME;
+import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.FOLDER_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.REGION;
@@ -44,11 +45,11 @@ public class S3SourceDataAddressValidator implements Validator<DataAddress> {
             }
         });
 
-        if (Stream.of(OBJECT_NAME, OBJECT_PREFIX)
+        if (Stream.of(OBJECT_NAME, OBJECT_PREFIX, FOLDER_NAME)
                 .map(dataAddress::getStringProperty)
                 .allMatch(it -> (it == null || it.isBlank()))) {
-            violations.add(violation("Either the '%s' or '%s' attribute must be provided."
-                    .formatted(OBJECT_NAME, OBJECT_PREFIX), OBJECT_NAME, null));
+            violations.add(violation("Either the '%s' or '%s' or '%s' attribute must be provided."
+                    .formatted(OBJECT_NAME, OBJECT_PREFIX, FOLDER_NAME), OBJECT_NAME, null));
         }
 
         if (violations.isEmpty()) {

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -27,15 +27,20 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
-- When only `folderName` is present, transfer all objects with keys that start with the specified `folderName`, knowing
-  it will be removed from the transferred object name unless a defined `objectName` is present in DataSink.
-- When only `objectPrefix` is present, transfer all objects with keys that start with the specified `objectPrefix`.
-- When `folderName` and `objectPrefix` are present, transfer all the objects with keys that start with the specified
-  `folderName` + `objectPrefix`. The first will be removed from the transferred object name unless a defined 
-  `objectName` is present in DataSink.
+- There are three different ways to select objects by specifying a `folderName` and/or a `objectPrefix`.
+  Objects in an S3 bucket are persisted under the same root directory (the bucket), and a structured organization is
+  achievable by using object key prefixes. There are cases where maintaining the key prefix in the data destination
+  is desirable but other cases where it's not.
+  When using `folderName`, one can aggregate objects contained within a folder like structure. The `folderName` part will
+  be removed in the destination.
+  Using `objectPrefix`, one can aggregate objects whose key is prefixed by the specified string. The property can still
+  be used for folder like aggregation but the prefix part will not be removed in the destination.
+  When used in combination, both properties will be used for object selection through the concatenation of `folderName`
+  with `objectPrefix` (`folderName` + `objectPrefix`). Similarly, the `folderName` part will be removed from the object name
+  in the destination.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
-- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to 
+- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to
   transfer. It allows for both multiple object transfers and fetching a single object when necessary.
 
 > Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -36,7 +36,7 @@ The behavior of object transfers can be customized using `DataAddress` propertie
   when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
   when necessary.
 
-> Note: Using `folderName` or `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter" (folderName + objectPrefix).
+> Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".
 
 ### S3DataSink Properties and behavior
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -27,14 +27,16 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
-- When `folderName` is present, transfer all objects with keys that start with the specified name. The folderName will
-  be removed from the transferred object name.
-- When `objectPrefix` is present, transfer all objects with keys that start with the specified prefix.
+- When only `folderName` is present, transfer all objects with keys that start with the specified `folderName`, knowing
+  it will be removed from the transferred object name unless a defined `objectName` is present in DataSink.
+- When only `objectPrefix` is present, transfer all objects with keys that start with the specified `objectPrefix`.
+- When `folderName` and `objectPrefix` are present, transfer all the objects with keys that start with the specified
+  `folderName` + `objectPrefix`. The first will be removed from the transferred object name unless a defined 
+  `objectName` is present in DataSink.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
-- Precedence: `folderName` takes precedence over `objectPrefix` and `objectPrefix` takes precedence over `objectName`
-  when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
-  when necessary.
+- Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to 
+  transfer. It allows for both multiple object transfers and fetching a single object when necessary.
 
 > Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -28,22 +28,23 @@ When as a source, it supports copying a single or multiple objects.
 The behavior of object transfers can be customized using `DataAddress` properties.
 
 - There are three different ways to select objects by specifying a `folderName` and/or a `objectPrefix`.
-  Objects in an S3 bucket are persisted under the same root directory (the bucket), and a structured organization is
-  achievable by using object key prefixes. There are cases where maintaining the key prefix in the data destination
+  Objects in an S3 bucket are persisted under the same root directory (the bucket), and a structured organization is 
+  achievable by using object key prefixes. There are cases where maintaining the key prefix in the data destination 
   is desirable but other cases where it's not.
   When using `folderName`, one can aggregate objects contained within a folder like structure. The `folderName` part will
   be removed in the destination.
   Using `objectPrefix`, one can aggregate objects whose key is prefixed by the specified string. The property can still
   be used for folder like aggregation but the prefix part will not be removed in the destination.
-  When used in combination, both properties will be used for object selection through the concatenation of `folderName`
-  with `objectPrefix` (`folderName` + `objectPrefix`). Similarly, the `folderName` part will be removed from the object name
+  When used in combination, both properties will be used for object selection through the concatenation of `folderName` 
+  with `objectPrefix` (`folderName` + `objectPrefix`). Similarly, the `folderName` part will be removed from the object name 
   in the destination.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
 - Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to
   transfer. It allows for both multiple object transfers and fetching a single object when necessary.
 
-> Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter".
+> Note: Using `folderName` or/and `objectPrefix` introduces an additional step to list all objects whose keys match the 
+  specified "filter".
 
 ### S3DataSink Properties and behavior
 

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -38,6 +38,8 @@ The behavior of object transfers can be customized using `DataAddress` propertie
   When used in combination, both properties will be used for object selection through the concatenation of `folderName` 
   with `objectPrefix` (`folderName` + `objectPrefix`). Similarly, the `folderName` part will be removed from the object name 
   in the destination.
+- When `folderName` attribute is requested as slash (folderName = "/") and `objectPrefix` is empty or null an entire s3 
+  bucket transfer is triggered.
 - When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
   property.
 - Precedence: `folderName` and/or `objectPrefix` take precedence over `objectName` when determining which objects to

--- a/extensions/data-plane/data-plane-aws-s3/README.md
+++ b/extensions/data-plane/data-plane-aws-s3/README.md
@@ -18,7 +18,7 @@ When as a source, it supports copying a single or multiple objects.
 | `bucketName`       | Defines the name of the S3 bucket                                      | `source`, `destination` | `true`                                                |
 | `objectName`       | Defines the name of the S3 object                                      | `source`, `destination` | `true` (in `source` if `objectPrefix` is not present) |
 | `objectPrefix`     | Defines the prefix of the S3 objects to be fetched ( `objectPrefix/` ) | `source`                | `true` (if `objectName` is not present)               |
-| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `destination`           | `false`                                               |
+| `folderName`       | Defines the folder name for S3 objects to be grouped ( `folderName/` ) | `source`, `destination` | `false`                                               |
 | `keyName`          | Defines the `vault` entry containing the secret token/credentials      | `source`, `destination` | `false`                                               |
 | `accessKeyId`      | Defines the access key id to access S3 Bucket/Object                   | `source`, `destination` | `false`                                               |
 | `secretAccessKey`  | Defines the secret access key id to access S3 Bucket/Object            | `source`, `destination` | `false`                                               |
@@ -27,12 +27,16 @@ When as a source, it supports copying a single or multiple objects.
 
 The behavior of object transfers can be customized using `DataAddress` properties.
 
+- When `folderName` is present, transfer all objects with keys that start with the specified name. The folderName will
+  be removed from the transferred object name.
 - When `objectPrefix` is present, transfer all objects with keys that start with the specified prefix.
-- When `objectPrefix` is not present, transfer only the object with a key matching the `objectName` property.
-- Precedence: `objectPrefix` takes precedence over `objectName` when determining which objects to transfer. It allows
-  for both multiple object transfers and fetching a single object when necessary.
+- When `folderName` and `objectPrefix` are not present, transfer only the object with a key matching the `objectName`
+  property.
+- Precedence: `folderName` takes precedence over `objectPrefix` and `objectPrefix` takes precedence over `objectName`
+  when determining which objects to transfer. It allows for both multiple object transfers and fetching a single object
+  when necessary.
 
-> Note: Using `objectPrefix` introduces an additional step to list all objects whose keys match the specified prefix.
+> Note: Using `folderName` or `objectPrefix` introduces an additional step to list all objects whose keys match the specified "filter" (folderName + objectPrefix).
 
 ### S3DataSink Properties and behavior
 
@@ -63,7 +67,7 @@ possible values are:
   typically
   referred to as AWS temporary security credentials. This process involves assuming an IAM role to obtain short-term
   credentials, which include an `accessKeyId`, `secretAccessKey`, and a session token. In addition to these fields,
-  the token expiration time, which is received together with the credentials upon assuming a role or otherwise 
+  the token expiration time, which is received together with the credentials upon assuming a role or otherwise
   requesting temporary credentials, has to be specified as a **unix timestamp**.
   ```json
   {
@@ -79,10 +83,10 @@ Example:
 ```json
 {
   "dataAddress": {
-    "type": "AmazonS3", 
-    "bucketName": "bucketName", 
-    "region": "us-east-1", 
-    "objectName": "test/object.bin", 
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "objectName": "test/object.bin",
     "keyName": "<SECRET_KEY_IN_VAULT>"
   }
 }
@@ -143,14 +147,14 @@ Example:
 - Single object:
 ```json
 {
-    "dataDestination": {
-      "type": "AmazonS3",
-      "bucketName": "bucketName",
-      "region": "us-east-1",
-      "folderName": "destinationFolder/",
-      "objectName": "newName",
-      "keyName": "(see above)"
-    }
+  "dataDestination": {
+    "type": "AmazonS3",
+    "bucketName": "bucketName",
+    "region": "us-east-1",
+    "folderName": "destinationFolder/",
+    "objectName": "newName",
+    "keyName": "(see above)"
+  }
 }
 ```
 
@@ -180,21 +184,21 @@ In order to be able to use an S3 bucket as the source of a transfer, the user/ro
 Example:
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "my-statement",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<bucket-name>",
-                "arn:aws:s3:::<bucket-name>/*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "my-statement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<bucket-name>",
+        "arn:aws:s3:::<bucket-name>/*"
+      ]
+    }
+  ]
 }
 ```
 
@@ -206,19 +210,19 @@ In order to be able to use an S3 bucket as the destination of a transfer, the us
 Example:
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "my-statement",
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::<bucket-name>/*"
-            ]
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "my-statement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<bucket-name>/*"
+      ]
+    }
+  ]
 }
 ```
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -125,7 +125,7 @@ class S3DataSource implements DataSource {
     }
 
     private String getRefinedFolderName(String folderName) {
-        if (isNullOrEmpty(folderName)) {
+        if (isNullOrEmpty(folderName) || folderName.equals("/")) {
             return "";
         }
         if (!folderName.endsWith("/")) {

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -68,7 +68,7 @@ class S3DataSource implements DataSource {
             objectFolderName += "/";
         }
 
-        if (!(objectFolderName == null && objectPrefix == null)) {
+        if (!(isNullOrEmpty(objectFolderName) && isNullOrEmpty(objectPrefix))) {
 
             var filter = getFilter(objectFolderName, objectPrefix);
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -125,8 +125,12 @@ class S3DataSource implements DataSource {
     }
 
     private String getRefinedFolderName(String folderName) {
-        if (isNullOrEmpty(folderName)) return "";
-        folderName += !folderName.endsWith("/") ? "/" : "";
+        if (isNullOrEmpty(folderName)) {
+            return "";
+        }
+        if (!folderName.endsWith("/")) {
+            return folderName + "/";
+        }
         return folderName;
     }
 

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSource.java
@@ -71,9 +71,7 @@ class S3DataSource implements DataSource {
         if (!(isNullOrEmpty(objectFolderName) && isNullOrEmpty(objectPrefix))) {
 
             var filter = getFilter(objectFolderName, objectPrefix);
-
             var s3Objects = this.fetchFilteredByFolderNameAndOrPrefixS3Objects(filter);
-
             objectFolderName = !(isNullOrEmpty(objectFolderName) || objectFolderName.equals("/")) ? objectFolderName : "";
 
             if (s3Objects.isEmpty()) {
@@ -111,7 +109,6 @@ class S3DataSource implements DataSource {
         List<S3Object> s3Objects = new ArrayList<>();
 
         do {
-
             var listObjectsRequest = ListObjectsV2Request.builder()
                     .bucket(bucketName)
                     .prefix(filter)
@@ -119,26 +116,18 @@ class S3DataSource implements DataSource {
                     .build();
 
             var response = client.listObjectsV2(listObjectsRequest);
-
             s3Objects.addAll(response.contents().stream().filter(isFile).toList());
-
             continuationToken = response.nextContinuationToken();
-
         } while (continuationToken != null);
 
         return s3Objects;
     }
 
     private String getFilter(String objectFolderName, String objectPrefix) {
-
-        StringBuilder filter = new StringBuilder();
-
         objectFolderName = objectFolderName != null ? objectFolderName : "";
         objectPrefix = objectPrefix != null ? objectPrefix : "";
 
-        filter.append(objectFolderName).append(objectPrefix);
-
-        return filter.toString();
+        return (objectFolderName + objectPrefix);
     }
 
     @Override

--- a/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/main/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataSourceFactory.java
@@ -44,6 +44,7 @@ import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.ACCESS_KEY_ID;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.BUCKET_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.ENDPOINT_OVERRIDE;
+import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.FOLDER_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_NAME;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.OBJECT_PREFIX;
 import static org.eclipse.edc.aws.s3.spi.S3BucketSchema.REGION;
@@ -85,6 +86,7 @@ public class S3DataSourceFactory implements DataSourceFactory {
                 .bucketName(source.getStringProperty(BUCKET_NAME))
                 .keyName(source.getKeyName())
                 .objectName(source.getStringProperty(OBJECT_NAME))
+                .folderName(source.getStringProperty(FOLDER_NAME))
                 .objectPrefix(source.getStringProperty(OBJECT_PREFIX))
                 .client(this.clientProvider.s3Client(s3ClientRequest))
                 .monitor(monitor)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -154,7 +154,7 @@ public class S3DataPlaneIntegrationTest {
 
     @ParameterizedTest
     @ArgumentsSource(MultiObjectsNamesToTransfer.class)
-    void shouldCopy_UsingDestinationfolderName_InMultiFileTransfer(String folderName, String prefix, List<String> objectNames) {
+    void shouldCopy_UsingDestinationFolderName_InMultiFileTransfer(String folderName, String prefix, List<String> objectNames) {
 
         var folderNameInDestination = "folder-name-in-destination/";
         var objectNameInDestination = "object-name-in-destination";

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -61,6 +61,7 @@ public class S3DataPlaneIntegrationTest {
     private static final String OBJECT_FOLDER_NAME = "object-folder-name/";
     private static final String OBJECT_PREFIX = "object-prefix/";
     private static final String KEY_NAME = "key-name";
+    private static final String OBJECT_NAME = "text-document.txt";
 
     @Container
     private final MinioContainer sourceMinio = new MinioContainer();
@@ -258,8 +259,6 @@ public class S3DataPlaneIntegrationTest {
 
     private static class SingleObjectNamesToTransfer implements ArgumentsProvider {
 
-        private static final String OBJECT_NAME = "text-document.txt";
-
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
             return Stream.of(
@@ -271,8 +270,6 @@ public class S3DataPlaneIntegrationTest {
     }
 
     private static class MultiObjectsNamesToTransfer implements ArgumentsProvider {
-
-        private static final String OBJECT_NAME = "text-document.txt";
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) {

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -142,9 +142,7 @@ public class S3DataPlaneIntegrationTest {
         assertThat(transferResult).succeedsWithin(5, SECONDS);
 
         for (var objectName : objectNames) {
-            var objectKeyInDestination = new StringBuilder();
-            objectKeyInDestination.append(folderNameInDestination);
-            objectKeyInDestination.append(objectName);
+            var objectKeyInDestination = folderNameInDestination + objectName;
 
             assertThat(destinationClient.getObject(destinationBucketName, objectKeyInDestination.toString()))
                     .succeedsWithin(5, SECONDS)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -142,9 +142,7 @@ public class S3DataPlaneIntegrationTest {
         assertThat(transferResult).succeedsWithin(5, SECONDS);
 
         for (var objectName : objectNames) {
-            var objectKeyInDestination = folderNameInDestination + objectName;
-
-            assertThat(destinationClient.getObject(destinationBucketName, objectKeyInDestination.toString()))
+            assertThat(destinationClient.getObject(destinationBucketName, folderNameInDestination + objectName))
                     .succeedsWithin(5, SECONDS)
                     .extracting(ResponseBytes::response)
                     .extracting(GetObjectResponse::contentLength)

--- a/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
+++ b/extensions/data-plane/data-plane-aws-s3/src/test/java/org/eclipse/edc/connector/dataplane/aws/s3/S3DataPlaneIntegrationTest.java
@@ -117,7 +117,7 @@ public class S3DataPlaneIntegrationTest {
         objectKey.append(name);
         sourceClient.putStringOnBucket(sourceBucketName, objectKey.toString(), objectContent);
 
-        var sourceAddress = singleObjectCreateDataAddress(folderName, prefix, name);
+        var sourceAddress = createSingleObjectDataAddress(folderName, prefix, name);
 
         var destinationAddress = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
@@ -175,7 +175,7 @@ public class S3DataPlaneIntegrationTest {
             sourceClient.putStringOnBucket(sourceBucketName, objectKey.toString(), objectContent);
         }
 
-        var sourceAddress = multiObjectsCreateDataAddress(folderName, prefix);
+        var sourceAddress = createMultiObjectsDataAddress(folderName, prefix);
 
         var destinationAddress = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
@@ -220,7 +220,7 @@ public class S3DataPlaneIntegrationTest {
         }
     }
 
-    private DataAddress singleObjectCreateDataAddress(String folderName, String prefix, String name) {
+    private DataAddress createSingleObjectDataAddress(String folderName, String prefix, String name) {
         var dataAddressBuilder = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
                 .keyName(KEY_NAME)
@@ -238,7 +238,7 @@ public class S3DataPlaneIntegrationTest {
         return dataAddressBuilder.property(S3BucketSchema.OBJECT_NAME, name).build();
     }
 
-    private DataAddress multiObjectsCreateDataAddress(String folderName, String prefix) {
+    private DataAddress createMultiObjectsDataAddress(String folderName, String prefix) {
         var dataAddressBuilder = DataAddress.Builder.newInstance()
                 .type(S3BucketSchema.TYPE)
                 .keyName(KEY_NAME)


### PR DESCRIPTION
## What this PR changes/adds

Add the possibility to transfer all objects in an S3 bucket.

## Why it does that

Product requirements to allow the transfer of the entire S3 bucket, rather than requiring the creation of a base folder containing transferable data.

To do a request of this type, use the slash ("/") as the value for the folderName attribute:
folderName = "/"

## Further notes

The solution proposed in #562  was not followed.

## Who will sponsor this feature?

toBeAdded

## Linked Issue(s)

Closes #562  